### PR TITLE
Automatically remove invalid ai parameters leftover from tensorflow

### DIFF
--- a/pwnagotchi/ai/__init__.py
+++ b/pwnagotchi/ai/__init__.py
@@ -23,6 +23,12 @@ def load(config, agent, epoch, from_disk=True):
         from stable_baselines3 import A2C
         logging.debug("[AI] A2C imported in %.2fs" % (time.time() - start))
 
+        # remove invalid ai.parameters leftover from tensor_flow, if present
+        for key in [ 'alpha', 'epsilon', 'lr_schedule' ]:
+            if key in config['params']:
+                logging.info("Removing legacy ai parameter %s" % key);
+                del config['params'][key]
+        
         start = time.time()
         from stable_baselines3.a2c import MlpPolicy
         logging.debug("[AI] MlpPolicy imported in %.2fs" % (time.time() - start))


### PR DESCRIPTION
Ease transition from old Pwnagotchi running tensor flow to new running torch, but automatically dumping the invalid parameters.

<!--- Provide a general summary of your changes in the Title above -->
Added a check after Stable Baselines 3 loads to remove invalid configuration parameters
## Description
<!--- Describe your changes in detail -->
There are 3 ai parameters used by TensorFlow that trigger an error in Torch when present. This change removes the parameters from the configuration dictionary before initializing the neural network. If someone copies their config.toml from a TensorFlow based Pwnagotchi, this will filter out the parameters that would cause Pwnagotchi to crash and restart over and over.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This eases transition from older pwnagotchis (evil socket, drschottkey, aluminum ice) to this version running torch instead of tensor flow.

<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested and running on multiple pwnagotchis (in other repo.  haven't tested since copying it here, but its self-contained and should be fine ;).  famous last words. ha!)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X] I have signed-off my commits with `git commit -s`
