### PR TITLE
Fix Waveshare V2 Position

### DIFF
--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -130,7 +130,7 @@ class MemTemp(plugins.Plugin):
         except Exception:
             # Set default position based on screen type
             if ui.is_waveshare_v2():
-                h_pos = (178, 84)
+                h_pos = (175, 84)
                 v_pos = (197, 74)
             elif ui.is_waveshare_v1():
                 h_pos = (170, 80)


### PR DESCRIPTION
## Description

The current location "178, 84" does not correctly display the temperature symbol (Cellsius, Kelvin, etc.). I fix the code whit the correct position.


## How Has This Been Tested?
Tested on Raspberry Pi Zero 2 with Waveshare V2

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
