### PR TITLE
Fix typo in ansible script

### DIFF
--- a/builder/raspberrypi32.yml
+++ b/builder/raspberrypi32.yml
@@ -62,7 +62,7 @@
         source: "https://github.com/jayofelony/bettercap.git"
         url: "https://github.com/jayofelony/bettercap/releases/download/2.32.2/bettercap-2.32.2-armhf.zip"
         ui: "https://github.com/bettercap/ui/releases/download/v1.3.0/ui.zip"
-      opwngrid:
+      pwngrid:
         source: "https://github.com/jayofelony/pwngrid.git"
         url: "https://github.com/jayofelony/pwngrid/releases/download/v1.10.7/pwngrid-1.10.7-armhf.zip"
       torch:


### PR DESCRIPTION
Fix typo in ansible script

## Description
The 32 bit ansible build script had a typo where the pwngrid var definition was called opwngrid. All other references t it failed.

## Motivation and Context
Allows build to complete; the 32 bit part threw an error before.

## How Has This Been Tested?
Build once afterwards, successfully.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ x] I have signed-off my commits with `git commit -s`
