### PR TITLE
Fix [#137 issue]: Incorrect use of assignment operator (=) instead of comparison operator (==) in draw method

### DIFF
--- a/pwnagotchi/ui/components.py
+++ b/pwnagotchi/ui/components.py
@@ -19,7 +19,7 @@ class Bitmap(Widget):
         self.image = Image.open(path)
 
     def draw(self, canvas, drawer):
-        if self.color = 0xFF:
+        if self.color == 0xFF:
             self.image = ImageOps.invert(self.image)
         canvas.paste(self.image, self.xy)
 


### PR DESCRIPTION
Fix [#137 issue]: Incorrect use of assignment operator (=) instead of comparison operator (==) in draw method

## Description
This change fixes an issue in the draw method of the ui/components.py file where the assignment operator (=) was used instead of the comparison operator (==) in an if statement. This would cause the self.image to be inverted unconditionally, which is not the intended behavior.

## Motivation and Context
This change is required to fix an issue where the self.image is always inverted, regardless of the value of self.color. This is because the assignment operator (=) was used instead of the comparison operator (==) in an if statement. This change fixes the issue by using the correct comparison operator, ensuring that the self.image is only inverted when self.color is equal to 0xFF.
This pull request fixes the issue reported in [#137](https://github.com/jayofelony/pwnagotchi/issues/137).
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
This change has been tested by running the pwnagotchi application and verifying that the self.image is only inverted when self.color is equal to 0xFF. The change has been tested on a Linux system with Python 3.8.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`

























