### PR TITLE
Fix 3.7 orientation

### DIFF
--- a/pwnagotchi/ui/hw/waveshare3in7.py
+++ b/pwnagotchi/ui/hw/waveshare3in7.py
@@ -10,8 +10,8 @@ class Waveshare3in7(DisplayImpl):
 
     def layout(self):
         fonts.setup(10, 8, 10, 18, 25, 9)
-        self._layout['width'] = 480
-        self._layout['height'] = 280
+        self._layout['width'] = 280
+        self._layout['height'] = 480
         self._layout['face'] = (0, 43)
         self._layout['name'] = (0, 14)
         self._layout['channel'] = (0, 0)


### PR DESCRIPTION
Fixed waveshare 3.7" e-ink display orientation to now default to landscape (currently default is portrait and changing the rotation in config does not resolve the issue)


