### PR TITLE
Add new configuration option "ui.showcursor" to enable or disable bli…

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -151,7 +151,7 @@ personality.throttle_a = 0.4
 personality.throttle_d = 0.9
 
 ui.invert = false # false = black background, true = white background
-
+ui.cursor = true
 ui.fps = 0.0
 ui.font.name = "DejaVuSansMono" # for japanese: fonts-japanese-gothic
 ui.font.size_offset = 0 # will be added to the font size

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -136,7 +136,7 @@ class View(object):
         delay = 1.0 / self._config['ui']['fps']
         while True:
             try:
-                if self._config['ui'].get('cursor', False) == True:
+                if self._config['ui'].get('cursor', True) == True:
                     name = self._state.get('name')
                     self.set('name', name.rstrip('█').strip() if '█' in name else (name + ' █'))
                 self.update()

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -136,7 +136,7 @@ class View(object):
         delay = 1.0 / self._config['ui']['fps']
         while True:
             try:
-                if 'showcursor' not in self._config['ui'] or self._config['ui']['showcursor'] == True:
+                if self._config['ui'].get('cursor', False) == True:
                     name = self._state.get('name')
                     self.set('name', name.rstrip('█').strip() if '█' in name else (name + ' █'))
                 self.update()

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -136,8 +136,9 @@ class View(object):
         delay = 1.0 / self._config['ui']['fps']
         while True:
             try:
-                name = self._state.get('name')
-                self.set('name', name.rstrip('█').strip() if '█' in name else (name + ' █'))
+                if 'showcursor' not in self._config['ui'] or self._config['ui']['showcursor'] == True:
+                    name = self._state.get('name')
+                    self.set('name', name.rstrip('█').strip() if '█' in name else (name + ' █'))
                 self.update()
             except Exception as e:
                 logging.warning("non fatal error while updating view: %s" % e)


### PR DESCRIPTION
…nking cursor by name

When ui.fps is not zero, the default UI adds a blinking cursor next to the pwnagotchi name, as a verification that the display is updating. This proposed change adds a configuration option "ui.showcursor" to allow users to disable the cursor. If ui.showcursor is set to "true" in config.toml, the cursor will show, if set "false" in config, the cursor will not be shown. Default behavior if ui.showcursor is not set is maintained (cursor will show). If ui.fps is set to 0, the cursor will not be shown regardless of the ui.showcursor setting.

(tested on a single pwny with showcursor unset, false, and true, multiple times)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
