### PR TITLE
Smart auto mode - partial channel scans each epoch with randomization

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -37,7 +37,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         self._tot_aps = 0
         self._aps_on_channel = 0
         self._supported_channels = utils.iface_channels(config['main']['iface'])
-        self._unscanned_channels = [] if 'channels' not in self.config['personality'] else self.config['personality']['channels'].copy()
+        self._unscanned_channels = [] if 'channels' not in self._config['personality'] else self._config['personality']['channels'].copy()
         self._view = view
         self._view.set_agent(self)
         self._web_ui = Server(self, config['ui'])

--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -210,7 +210,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         grouped = {}
         if len(self._unscanned_channels) == 0:
             self._unscanned_channels = self._supported_channels
-        logging.info("unscanned: %s" % repr(self._unscanned_channels))
+        logging.info("unscanned %d: %s" % (len(self._unscanned_channels), repr(self._unscanned_channels)))
 
         # group by channel
         for ap in aps:

--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -229,15 +229,15 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                 grouped[ch].append(ap)
 
         if not ai_enabled:
-            logging.info("unscanned %d: %s" % (len(self._unscanned_channels), repr(self._unscanned_channels)))
-            logging.info("Adding %d extra channels: %s" % (extra_channels, repr(next_channels)))
+            logging.debug("unscanned %d: %s" % (len(self._unscanned_channels), repr(self._unscanned_channels)))
+            logging.debug("%d Active channels: %s" % (next_channels.len(), repr(next_channels)))
             for i in range(extra_channels):
                 if len(self._unscanned_channels):
                     ch = random.choice(list(self._unscanned_channels))
                     self._unscanned_channels.remove(ch)
                     next_channels.append(ch)
             self._config['personality']['channels'] = next_channels
-            logging.info("Next recon: %s" % repr(next_channels))
+            logging.info("Next recon set: %s" % repr(next_channels))
 
         # sort by more populated channels
         return sorted(grouped.items(), key=lambda kv: len(kv[1]), reverse=True)

--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -5,6 +5,7 @@ import re
 import logging
 import asyncio
 import _thread
+import random
 
 import pwnagotchi
 import pwnagotchi.utils as utils
@@ -36,6 +37,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         self._tot_aps = 0
         self._aps_on_channel = 0
         self._supported_channels = utils.iface_channels(config['main']['iface'])
+        self._unscanned_channels = [] if 'channels' not in self.config['personality'] else self.config['personality']['channels']
         self._view = view
         self._view.set_agent(self)
         self._web_ui = Server(self, config['ui'])
@@ -201,20 +203,40 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
     def get_access_points_by_channel(self):
         aps = self.get_access_points()
         channels = self._config['personality']['channels']
+        # number of "empty" channels to add to scan on each loop
+        extra_channels = 15 if 'extra_channels' not in self._config['personality'] else self._config['personality']['extra_channels']
+        next_channels = []
+        ai_enabled = self._config['ai']['enabled']
         grouped = {}
+        if len(self._unscanned_channels) == 0:
+            self._unscanned_channels = self._allowed_channels
+        logging.info("unscanned: %s" % repr(self._unscanned_channels))
 
         # group by channel
         for ap in aps:
             ch = ap['channel']
             # if we're sticking to a channel, skip anything
             # which is not on that channel
-            if channels and ch not in channels:
+            if ai_enabled and channels and ch not in channels:
                 continue
 
             if ch not in grouped:
                 grouped[ch] = [ap]
+                if ch in self._unscanned_channels:
+                    self._unscanned_channels.remove(ch)
+                next_channels.append(ch)
             else:
                 grouped[ch].append(ap)
+
+        if not ai_enabled:
+            logging.info("Adding %d extra channels: %s" % (extra_channels, repr(next_channels)))
+            for i in range(extra_channels):
+                if len(self._unscanned_channels):
+                    ch = random.choice(list(self._unscanned_channels))
+                    self._unscanned_channels.remove(ch)
+                    next_channels.append(ch)
+            self._config['personality']['channels'] = next_channels
+            logging.info("Next recon: %s" % repr(next_channels))
 
         # sort by more populated channels
         return sorted(grouped.items(), key=lambda kv: len(kv[1]), reverse=True)

--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -37,7 +37,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         self._tot_aps = 0
         self._aps_on_channel = 0
         self._supported_channels = utils.iface_channels(config['main']['iface'])
-        self._unscanned_channels = [] if 'channels' not in self.config['personality'] else self.config['personality']['channels']
+        self._unscanned_channels = [] if 'channels' not in self.config['personality'] else self.config['personality']['channels'].copy()
         self._view = view
         self._view.set_agent(self)
         self._web_ui = Server(self, config['ui'])
@@ -208,9 +208,9 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         next_channels = []
         ai_enabled = self._config['ai']['enabled']
         grouped = {}
+        
         if len(self._unscanned_channels) == 0:
-            self._unscanned_channels = self._supported_channels
-        logging.info("unscanned %d: %s" % (len(self._unscanned_channels), repr(self._unscanned_channels)))
+            self._unscanned_channels = self._supported_channels.copy()
 
         # group by channel
         for ap in aps:
@@ -229,6 +229,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                 grouped[ch].append(ap)
 
         if not ai_enabled:
+            logging.info("unscanned %d: %s" % (len(self._unscanned_channels), repr(self._unscanned_channels)))
             logging.info("Adding %d extra channels: %s" % (extra_channels, repr(next_channels)))
             for i in range(extra_channels):
                 if len(self._unscanned_channels):

--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -209,7 +209,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         ai_enabled = self._config['ai']['enabled']
         grouped = {}
         if len(self._unscanned_channels) == 0:
-            self._unscanned_channels = self._allowed_channels
+            self._unscanned_channels = self._supported_channels
         logging.info("unscanned: %s" % repr(self._unscanned_channels))
 
         # group by channel

--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -230,7 +230,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
 
         if not ai_enabled:
             logging.debug("unscanned %d: %s" % (len(self._unscanned_channels), repr(self._unscanned_channels)))
-            logging.debug("%d Active channels: %s" % (next_channels.len(), repr(next_channels)))
+            logging.debug("%d Active channels: %s" % (len(next_channels), repr(next_channels)))
             for i in range(extra_channels):
                 if len(self._unscanned_channels):
                     ch = random.choice(list(self._unscanned_channels))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modified AUTO mode to change the set of channels it scans every epoch. It keeps channels it found APs on, then randomly picks a configurable number of channels from the "unoccupied" channels. It keeps track of unscanned channels, and goes through them all before repeating (except busy channels, which are scanned every epoch).

## Description
<!--- Describe your changes in detail -->
Modified agent.py.  Added a variable to __init__ to track the "unscanned_channels".

Modified get_access_points_by_channel() to update channel list if config "ai.enabled" is false.  The next recon set will be made up of all "active" channels where pwnagotchi saw APs, and a configurable number of randomly selected channels (config.toml: personality.extra_channels  = 15 (default, which should scan all 5Ghz channels within 3-4 epochs).

if ai.enabled is true, the old behavior (AI updates personality variables) is unchanged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Lets you get rid of AI, without having to waste time scanning every unused channel every epoch. It does the random channel selection that the AI does. Other personality parameters (RSSI limits, timing, etc) get the values from config.toml. You can adjust those by editing config.toml and restarting, or by using webcfg plugin. recon_time is how many seconds pwnagotchi leaves bettercap scanning the channel list. Then min_recon_time is how long it spends on each active channel, performing attacks and waiting for handshakes. You can control the length of an epoch by modifying those. An epoch seems to last (recon_time + active_channels * min_recon_time) seconds. If you make them too low, it might miss some beacons.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a problem where not having AI active leaves the pwny scanning a static list of channels. Now it is dynamic in AUTO. :)
- [ X ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on a bananapim4zero, then on a jayofelony 2.8.6 image, by replacing the agent.py file in /usr/local/lib/python3.11/dist-packages/pwnagotchi. Debugged and reduced logging output to just show the next set of channels (like how AI mode does, but just the channels, since that is all that is changing)
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
