### PR TITLE
waveshare e-lnk 2.13 V3/V4 update

### DIFF
--- a/pwnagotchi/ui/hw/waveshare2in13_V3.py
+++ b/pwnagotchi/ui/hw/waveshare2in13_V3.py
@@ -2,6 +2,7 @@ import logging
 
 import pwnagotchi.ui.fonts as fonts
 from pwnagotchi.ui.hw.base import DisplayImpl
+from PIL import Image,ImageDraw,ImageFont
 
 
 class WaveshareV3(DisplayImpl):
@@ -37,6 +38,14 @@ class WaveshareV3(DisplayImpl):
         self._display = EPD()
         self._display.init()
         self._display.Clear(0xFF)
+        try:
+            new_image = Image.new('1', ( self._display.height,  self._display.width), 255)
+            buf = self._display.getbuffer(new_image)
+            self._display.displayPartBaseImage(buf)
+        except Exception as e: 
+            logging.info(e)
+
+        logging.info("initializing waveshare v3 display done")
 
     def render(self, canvas):
         buf = self._display.getbuffer(canvas)

--- a/pwnagotchi/ui/hw/waveshare2in13_V4.py
+++ b/pwnagotchi/ui/hw/waveshare2in13_V4.py
@@ -3,6 +3,7 @@ import logging
 import pwnagotchi.ui.fonts as fonts
 from pwnagotchi.ui.hw.base import DisplayImpl
 
+from PIL import Image,ImageDraw,ImageFont
 
 class WaveshareV4(DisplayImpl):
     def __init__(self, config):
@@ -36,6 +37,14 @@ class WaveshareV4(DisplayImpl):
         self._display = EPD()
         self._display.init()
         self._display.Clear(0xFF)
+        try:
+            new_image = Image.new('1', ( self._display.height,  self._display.width), 255)
+            buf = self._display.getbuffer(new_image)
+            self._display.displayPartBaseImage(buf)
+        except Exception as e: 
+            logging.info(e)
+
+        logging.info("initializing waveshare v2in13_V4 display done")
 
     def render(self, canvas):
         buf = self._display.getbuffer(canvas)


### PR DESCRIPTION
Optimize the initialization function to resolve the issue of noise in the first few frames caused by the lack of buffer initialization.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current image exhibits noise in the first few frames after each global refresh.
The reason is that the output buffer is not cleared after the refresh, resulting in the reading of random data, which causes the noise.


## How Has This Been Tested?
It has been tested on Raspberry Pi Zero 2W + PiSugar3 + waveshare V3/V4 e-ink display.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
