### PR TITLE
Fix build 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,15 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - name: "Raspberry Pi 32-bit"
+          id: "32bit"  
+        - name: "Raspberry Pi 64-bit"
+          id: "64bit" 
 
     steps:
       - uses: actions/checkout@v4
@@ -23,27 +31,21 @@ jobs:
       - name: Install qemu dependencies
         run: sudo apt update && sudo apt install qemu-user-static qemu-utils xz-utils -y
 
-      - name: Build img file
-        run: ls -la .; pwd; make all
+      - name: Build ${{ matrix.name }} img file
+        run: ls -la .; pwd; make packer; make ${{ matrix.id }}
 
-      - name: Transfer 32bit.img to docker and give permissions
-        run: sudo chown runner:docker "pwnagotchi-32bit.img"
-
-      - name: Transfer 64bit.img to docker and give permissions
-        run: sudo chown runner:docker "pwnagotchi-64bit.img"
+      - name: Transfer ${{ matrix.name }} .img to docker and give permissions
+        run: sudo chown runner:docker "pwnagotchi-${{ matrix.id }}.img"
 
       - name: PiShrink
         run: |
           wget https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh
           chmod +x pishrink.sh
           sudo mv pishrink.sh /usr/local/bin
-          find /home/runner/work/ -type f -name "*.img" -exec sudo pishrink.sh -aZ {} \;
+          find /home/runner/work/ -type f -name "pwnagotchi-${{ matrix.id }}.img" -exec sudo pishrink.sh -aZ {} \;
 
-      - name: Change name of 32.img.xz to add version
-        run: mv "pwnagotchi-32bit.img.xz" "pwnagotchi-$VERSION-32bit.img.xz"
-
-      - name: Change name of 64.img.xz to add version
-        run: mv "pwnagotchi-64bit.img.xz" "pwnagotchi-$VERSION-64bit.img.xz"
+      - name: Change name of .img.xz to add version
+        run: mv "pwnagotchi-${{ matrix.id }}.img.xz" "pwnagotchi-${{ env.VERSION }}-${{ matrix.id }}.img.xz"
 
       - name: Release
         uses: softprops/action-gh-release@v2
@@ -52,7 +54,5 @@ jobs:
           make_latest: true
           tag_name: v${{ env.VERSION }}
           name: Pwnagotchi v${{ env.VERSION }}
-          files: |
-              pwnagotchi-${{ env.VERSION }}-32bit.img.xz
-              pwnagotchi-${{ env.VERSION }}-64bit.img.xz
+          files: pwnagotchi-${{ env.VERSION }}-${{ matrix.id }}.img.xz
           generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,31 +21,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: publish/build
 
       - name: Extract version from file
         id: get_version
         run: |
-          VERSION=$(cut -d "'" -f2 < pwnagotchi/_version.py)
+          VERSION=$(cut -d "'" -f2 < publish/build/pwnagotchi/_version.py)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Install qemu dependencies
         run: sudo apt update && sudo apt install qemu-user-static qemu-utils xz-utils -y
 
       - name: Build ${{ matrix.name }} img file
-        run: ls -la .; pwd; make packer; make ${{ matrix.id }}
-
-      - name: Transfer ${{ matrix.name }} .img to docker and give permissions
-        run: sudo chown runner:docker "pwnagotchi-${{ matrix.id }}.img"
+        run: cd publish/build; ls -la .; pwd; make packer; make ${{ matrix.id }}
+      
+      - name: Change name of .img.xz to add version
+        run: |
+          sudo chown runner:docker "pwnagotchi-${{ matrix.id }}.img"
+          mv "pwnagotchi-${{ matrix.id }}.img" "pwnagotchi-${{ env.VERSION }}-${{ matrix.id }}.img"
 
       - name: PiShrink
         run: |
           wget https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh
           chmod +x pishrink.sh
           sudo mv pishrink.sh /usr/local/bin
-          find /home/runner/work/ -type f -name "pwnagotchi-${{ matrix.id }}.img" -exec sudo pishrink.sh -aZ {} \;
-
-      - name: Change name of .img.xz to add version
-        run: mv "pwnagotchi-${{ matrix.id }}.img.xz" "pwnagotchi-${{ env.VERSION }}-${{ matrix.id }}.img.xz"
+          sudo pishrink.sh -aZ "pwnagotchi-${{ env.VERSION }}-${{ matrix.id }}.img"
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,6 @@ name: Publish
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version number'
-        required: true
 
 jobs:
   build:

--- a/builder/raspberrypi32.yml
+++ b/builder/raspberrypi32.yml
@@ -90,7 +90,7 @@
           - libopenblas-dev # https://stackoverflow.com/questions/14570011/explain-why-numpy-should-not-be-imported-from-source-directory
           - libopenjp2-7
           - libpcap-dev
-          - libraspberrypi-bin
+          #- libraspberrypi-bin      ## seems to be provided by raspi-utils now
           - libraspberrypi-dev
           - libraspberrypi-doc
           - libraspberrypi0

--- a/builder/raspberrypi64.yml
+++ b/builder/raspberrypi64.yml
@@ -83,7 +83,7 @@
           - libgmp3-dev
           - libnetfilter-queue-dev
           - libpcap-dev
-          - libraspberrypi-bin
+          #- libraspberrypi-bin      ## seems to be provided by raspi-utils now
           - libraspberrypi-dev
           - libraspberrypi-doc
           - libraspberrypi0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

fixes github action publish and and binformat error, also failing build due to libraspberry pi-dev :

## Description
<!--- Describe your changes in detail -->

github action was failing, build was failng to  a weird binformat error, so
- i changed it to use `builder/raspberrypi32.json.pkr.hcl` and `builder/raspberrypi64.json.pkr.hcl` instead of combined 
- i used a matrix strategy in the github yml to make both images at the same time instead.

also, a recent commit, changed the output of the files from `../../outputfile.img` to `../../../outputfile.img`, i noticed this puts the image outside of the github action's work dir, but i made the assumption it was for your local builds, so rather than change the output file dir, i just compensated by making two unnecessary directories for the checkout and build process in the workflow file. 

## Motivation and Context
i plan on making this work on some other boards, wanted to use github actions.

## How Has This Been Tested?
all in github actions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have signed-off my commits with `git commit -s`
