### PR TITLE
add mode parameter to agent._restart, and call agent._restart from US…

### DIFF
--- a/bin/pwnagotchi
+++ b/bin/pwnagotchi
@@ -323,7 +323,7 @@ def pwnagotchi_cli():
 
     def usr1_handler(*unused):
         logging.info('Received USR1 singal. Restart process ...')
-        restart("MANU" if args.do_manual else "AUTO")
+        agent._restart("MANU" if args.do_manual else "AUTO")
 
     signal.signal(signal.SIGUSR1, usr1_handler)
 

--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -269,9 +269,9 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         self._save_recovery_data()
         pwnagotchi.reboot()
 
-    def _restart(self):
+    def _restart(self, mode='AUTO'):
         self._save_recovery_data()
-        pwnagotchi.restart("AUTO")
+        pwnagotchi.restart(mode)
 
     def _save_recovery_data(self):
         logging.warning("writing recovery data to %s ...", RECOVERY_DATA_FILE)


### PR DESCRIPTION
Change pwnagotchi to maintain session stats across "pwnkill" restarts.

<!--- Provide a general summary of your changes in the Title above -->

Modified bin/pwnagotchi to call agent._restart() instead of pwnagotchi.restart(). agent._restart() saves the current session stats as "recovery data" and reloads it on the next startup instead of starting at 0. Also modified agent._restart() to take a mode parameter, so the pwny will restart in the same mode as it was.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

This is in response to a user request to maintain stats across intentional restarts. When the pwny goes blind and restarts itself, it saves the recovery data so after it reboots, it continues the previous session. This change adapts that same behavior to "pwnkill" restarts. "pwnkill" is frequently used to add new plugins and other maintenance. Resetting stats does not always seem appropriate.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on a live pwny, running 'pwnkill' and watching the logs to see it working.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`

I forgot to "-s" the commit, but I committed it :)
