### PR TITLE
adding 4 new displays

### DIFF
--- a/pwnagotchi/ui/display.py
+++ b/pwnagotchi/ui/display.py
@@ -253,9 +253,18 @@ class Display(View):
 
     def is_spotpear24inch(self):
         return self._implementation.name == 'spotpear24inch'
+    
+    def is_spotpear154lcd(self):
+        return self._implementation.name == 'spotpear154lcd'
 
     def is_displayhatmini(self):
         return self._implementation.name == 'displayhatmini'
+    
+    def is_gamepi20(self):
+        return self._implementation.name == 'gamepi20'
+
+    def is_gamepi15(self):
+        return self._implementation.name == 'gamepi15'
 
     def is_pirateaudio(self):
         return self._implementation.name == 'pirateaudio'

--- a/pwnagotchi/ui/hw/__init__.py
+++ b/pwnagotchi/ui/hw/__init__.py
@@ -87,6 +87,10 @@ def display_for(config):
     elif config['ui']['display']['type'] == 'spotpear24inch':
         from pwnagotchi.ui.hw.spotpear24in import Spotpear24inch
         return Spotpear24inch(config)
+    
+    elif config['ui']['display']['type'] == 'spotpear154lcd':
+        from pwnagotchi.ui.hw.spotpear154lcd import Spotpear154lcd
+        return Spotpear154lcd(config)
 
     elif config['ui']['display']['type'] == 'displayhatmini':
         from pwnagotchi.ui.hw.displayhatmini import DisplayHatMini
@@ -107,6 +111,14 @@ def display_for(config):
     elif config['ui']['display']['type'] == 'pitft':
         from pwnagotchi.ui.hw.pitft import Pitft
         return Pitft(config)
+    
+    elif config['ui']['display']['type'] == 'gamepi15':
+        from pwnagotchi.ui.hw.gamepi15 import GamePi15
+        return GamePi15(config)
+    
+    elif config['ui']['display']['type'] == 'gamepi20':
+        from pwnagotchi.ui.hw.gamepi20 import GamePi20
+        return GamePi20(config)
 
     elif config['ui']['display']['type'] == 'minipitft':
         from pwnagotchi.ui.hw.minipitft import MiniPitft

--- a/pwnagotchi/ui/hw/gamepi15.py
+++ b/pwnagotchi/ui/hw/gamepi15.py
@@ -1,0 +1,43 @@
+import logging
+
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.hw.base import DisplayImpl
+
+
+class GamePi15(DisplayImpl):
+    def __init__(self, config):
+        super(GamePi15, self).__init__(config, 'gamepi15')
+
+    def layout(self):
+        fonts.setup(10, 9, 10, 35, 25, 9)
+        self._layout['width'] = 240
+        self._layout['height'] = 240
+        self._layout['face'] = (0, 40)
+        self._layout['name'] = (5, 20)
+        self._layout['channel'] = (0, 0)
+        self._layout['aps'] = (28, 0)
+        self._layout['uptime'] = (175, 0)
+        self._layout['line1'] = [0, 14, 240, 14]
+        self._layout['line2'] = [0, 108, 240, 108]
+        self._layout['friend_face'] = (0, 92)
+        self._layout['friend_name'] = (40, 94)
+        self._layout['shakes'] = (0, 109)
+        self._layout['mode'] = (215, 109)
+        self._layout['status'] = {
+            'pos': (125, 20),
+            'font': fonts.status_font(fonts.Medium),
+            'max': 20
+        }
+
+        return self._layout
+
+    def initialize(self):
+        logging.info("initializing gamepi20 display")
+        from pwnagotchi.ui.hw.libs.pimoroni.displayhatmini.ST7789 import ST7789
+        self._display = ST7789(0, 0, 25, 24, 27, 240, 240, 270, True, 60 * 1000 * 1000, 0, 0)
+
+    def render(self, canvas):
+        self._display.display(canvas)
+
+    def clear(self):
+        self._display.clear()

--- a/pwnagotchi/ui/hw/gamepi20.py
+++ b/pwnagotchi/ui/hw/gamepi20.py
@@ -1,0 +1,43 @@
+import logging
+
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.hw.base import DisplayImpl
+
+
+class GamePi20(DisplayImpl):
+    def __init__(self, config):
+        super(GamePi20, self).__init__(config, 'gamepi20')
+
+    def layout(self):
+        fonts.setup(12, 10, 12, 70, 25, 9)
+        self._layout['width'] = 320
+        self._layout['height'] = 240
+        self._layout['face'] = (35, 50)
+        self._layout['name'] = (5, 20)
+        self._layout['channel'] = (0, 0)
+        self._layout['aps'] = (40, 0)
+        self._layout['uptime'] = (240, 0)
+        self._layout['line1'] = [0, 14, 320, 14]
+        self._layout['line2'] = [0, 220, 320, 220]
+        self._layout['friend_face'] = (0, 130)
+        self._layout['friend_name'] = (40, 135)
+        self._layout['shakes'] = (0, 220)
+        self._layout['mode'] = (280, 220)
+        self._layout['status'] = {
+            'pos': (80, 160),
+            'font': fonts.status_font(fonts.Medium),
+            'max': 20
+        }
+
+        return self._layout
+
+    def initialize(self):
+        logging.info("initializing gamepi20 display")
+        from pwnagotchi.ui.hw.libs.pimoroni.displayhatmini.ST7789 import ST7789
+        self._display = ST7789(0, 0, 25, 24, 27, 320, 240, 0, True, 60 * 1000 * 1000, 0, 0)
+
+    def render(self, canvas):
+        self._display.display(canvas)
+
+    def clear(self):
+        self._display.clear()

--- a/pwnagotchi/ui/hw/spotpear154lcd.py
+++ b/pwnagotchi/ui/hw/spotpear154lcd.py
@@ -1,0 +1,43 @@
+import logging
+
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.hw.base import DisplayImpl
+
+
+class Spotpear154lcd(DisplayImpl):
+    def __init__(self, config):
+        super(Spotpear154lcd, self).__init__(config, 'spotpear154lcd')
+
+    def layout(self):
+        fonts.setup(10, 9, 10, 35, 25, 9)
+        self._layout['width'] = 240
+        self._layout['height'] = 240
+        self._layout['face'] = (0, 40)
+        self._layout['name'] = (5, 20)
+        self._layout['channel'] = (0, 0)
+        self._layout['aps'] = (28, 0)
+        self._layout['uptime'] = (175, 0)
+        self._layout['line1'] = [0, 14, 240, 14]
+        self._layout['line2'] = [0, 108, 240, 108]
+        self._layout['friend_face'] = (0, 92)
+        self._layout['friend_name'] = (40, 94)
+        self._layout['shakes'] = (0, 109)
+        self._layout['mode'] = (215, 109)
+        self._layout['status'] = {
+            'pos': (125, 20),
+            'font': fonts.status_font(fonts.Medium),
+            'max': 20
+        }
+
+        return self._layout
+
+    def initialize(self):
+        logging.info("initializing gamepi15 display")
+        from pwnagotchi.ui.hw.libs.pimoroni.displayhatmini.ST7789 import ST7789
+        self._display = ST7789(0, 0, 22, 24, 27, 240, 240, 0, True, 60 * 1000 * 1000, 0, 0)
+
+    def render(self, canvas):
+        self._display.display(canvas)
+
+    def clear(self):
+        self._display.clear()

--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -303,6 +303,9 @@ def load_config(args):
     elif config['ui']['display']['type'] in ('spotpear24inch'):
         config['ui']['display']['type'] = 'spotpear24inch'
 
+    elif config['ui']['display']['type'] in ('spotpear154lcd'):
+        config['ui']['display']['type'] = 'spotpear154lcd'
+
     elif config['ui']['display']['type'] in ('displayhatmini'):
         config['ui']['display']['type'] = 'displayhatmini'
 
@@ -338,6 +341,12 @@ def load_config(args):
 
     elif config['ui']['display']['type'] in ('waveshareoledlcdvert'):
         config['ui']['display']['type'] = 'waveshareoledlcdvert'
+
+    elif config['ui']['display']['type'] in ('gamepi20'):
+        config['ui']['display']['type'] = 'gamepi20'
+
+    elif config['ui']['display']['type'] in ('gamepi15'):
+        config['ui']['display']['type'] = 'gamepi15'
 
     # E-INK DISPLAYS ------------------------------------------------------------------------
 


### PR DESCRIPTION
Adding the gamepi15, gamepi20 and the spotpeasr154lcd

## Description
All those screens are using the ST7789 from the displayhatmini driver file.

[gamepi15](https://www.waveshare.com/wiki/GamePi15)
[gamepi15 (spotpear)](https://spotpear.com/index/study/detail/id/497.html)
[gamepi20](https://www.waveshare.com/wiki/GamePi20)
[spotpear154lcd](https://spotpear.com/wiki/Raspberry-Pi-Game-1.54inch-LCD-touchscreen-display-ST7789.html)

## Motivation and Context
With the new Fancygotchi 2.0 features, hats with buttons will be more useful.

## How Has This Been Tested?
They are properly tested on different boards

## Types of changes
I only added the right display reference to use the DHM ST7789
