### PR TITLE
Add session stats reporting to AUTO mode

### DIFF
--- a/pwnagotchi/cli.py
+++ b/pwnagotchi/cli.py
@@ -48,6 +48,7 @@ def pwnagotchi_cli():
         logging.info("entering auto mode ...")
 
         agent.mode = 'auto'
+        agent.last_session.parse(agent.view(), args.skip_session)  # show stats in AUTO
         agent.start()
 
         while True:


### PR DESCRIPTION
add MANU session stats to AUTO mode, too

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Copied the line from do_manual_mode that generates the "last session" stats. Pwngrid will automatically report them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For users who never use MANU mode, session stats on opwngrid are always 0s. With this change, they get reported in AUTO, too, so more stats!

<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on multiple pwnagotchis. Tested by making the code change, and restarting. Then wait for some attacks and handshakes and restart. Then monitor opwngrid for updates to see that they match what happened in the previous session.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Kind of a new feature, but more of an enhancement. Is there any reason to not report in AUTO mode? Maybe an edge-case privacy issue, but if one wants privacy in their pony, they should probably turn off reporting completely.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X ] I have signed-off my commits with `git commit -s`
