### PR TITLE
Move self._view_on_starting() outside of loading keys exception

### DIFF
--- a/pwnagotchi/identity.py
+++ b/pwnagotchi/identity.py
@@ -50,10 +50,6 @@ class KeyPair(object):
                 with open(self.fingerprint_path, 'w+t') as fp:
                     fp.write(self.fingerprint)
 
-                # no exception, keys loaded correctly.
-                self._view.on_starting()
-                return
-
             except Exception as e:
                 # if we're here, loading the keys broke something ...
                 logging.exception("error loading keys, maybe corrupted, deleting and regenerating ...")
@@ -63,6 +59,9 @@ class KeyPair(object):
                 except:
                     pass
 
+            # no exception, keys loaded correctly.
+            self._view.on_starting()
+            return
     def sign(self, message):
         hasher = SHA256.new(message.encode("ascii"))
         signer = PKCS1_PSS.new(self.priv_key, saltLen=16)


### PR DESCRIPTION
When _view_on_starting is inside the try:except:, any display errors, especially from misconfigured plugins, will trigger the exception and delete RSA keys unnecessarily. By moving _view_on_starting after the except: clause, only errors during key loading will lead to deleted keys. view errors will silently fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Solves the problem of random errors deleting id_rsa keys.

<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on several of my pwnies on raspberry pi and bananapi.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X ] I have signed-off my commits with `git commit -s`
