### PR TITLE
Web redirections for OHCAPI and Wigle

### DIFF
--- a/pwnagotchi/plugins/default/grid.py
+++ b/pwnagotchi/plugins/default/grid.py
@@ -44,7 +44,7 @@ def parse_pcap(filename):
 
 class Grid(plugins.Plugin):
     __author__ = 'evilsocket@gmail.com'
-    __version__ = '1.0.1'
+    __version__ = '1.1.0'
     __license__ = 'GPL3'
     __description__ = 'This plugin signals the unit cryptographic identity and list of pwned networks and list of pwned ' \
                       'networks to opwngrid.xyz '
@@ -68,6 +68,11 @@ class Grid(plugins.Plugin):
 
     def on_loaded(self):
         logging.info("grid plugin loaded.")
+
+    def on_webhook(self, path, request):
+        from flask import make_response, redirect
+        response = make_response(redirect("https://opwngrid.xyz", code=302))
+        return response
 
     def set_reported(self, reported, net_id):
         if net_id not in reported:

--- a/pwnagotchi/plugins/default/ohcapi.py
+++ b/pwnagotchi/plugins/default/ohcapi.py
@@ -45,6 +45,11 @@ class ohcapi(plugins.Plugin):
         self.ready = True
         logging.info("OHC NewAPI: Plugin loaded and ready.")
 
+    def on_webhook(self, path, request):
+        from flask import make_response, redirect
+        response = make_response(redirect("https://www.onlinehashcrack.com", code=302))
+        return response
+    
     def on_internet_available(self, agent):
         """
         Called once when the internet becomes available.

--- a/pwnagotchi/plugins/default/wigle.py
+++ b/pwnagotchi/plugins/default/wigle.py
@@ -133,7 +133,6 @@ class Wigle(plugins.Plugin):
         response = make_response(redirect("https://www.wigle.net/", code=302))
         return response
 
-
     def on_internet_available(self, agent):
         """
         Called when there's internet connectivity

--- a/pwnagotchi/plugins/default/wigle.py
+++ b/pwnagotchi/plugins/default/wigle.py
@@ -127,6 +127,12 @@ class Wigle(plugins.Plugin):
 
         self.ready = True
         logging.info("WIGLE: ready")
+    
+    def on_webhook(self, path, request):
+        from flask import make_response, redirect
+        response = make_response(redirect("https://www.wigle.net/", code=302))
+        return response
+
 
     def on_internet_available(self, agent):
         """


### PR DESCRIPTION
Web redirections for OHCAPI and Wigle to match WPA-SEC plugin behaviour 
## Description
Quick URL redirection in the plugin page for OHCAPI and Wiggle

## Motivation and Context
Consistance behaviour between plugins

## How Has This Been Tested?
Local testing, no side effects

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
