### PR TITLE
Log entry when Pwnagotchi is Re|Started

### DIFF
--- a/pwnagotchi/log.py
+++ b/pwnagotchi/log.py
@@ -268,6 +268,7 @@ def setup_logging(args, config):
         requests_log.addHandler(logging.NullHandler())
         requests_log.prpagate = False
 
+    logging.info("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- Pwnagotchi Re|Started -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-")
 
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a line to the log file to identify when pwnagotchi was restarted

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When debugging or troubleshooting it's hard to tell when the last session stopped and the new one began.
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Did this to my own unit. Been running it for a couple of weeks.
It's a log entry - not much can go wrong.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
