### PR TITLE
Toml two times baby

### DIFF
--- a/pwnagotchi/ui/hw/dummydisplay.py
+++ b/pwnagotchi/ui/hw/dummydisplay.py
@@ -7,6 +7,7 @@ from pwnagotchi.ui.hw.base import DisplayImpl
 class DummyDisplay(DisplayImpl):
     def __init__(self, config):
         super(DummyDisplay, self).__init__(config, 'DummyDisplay')
+        self._display = self
 
     def layout(self):
         width = 480 if 'width' not in self.config else self.config['width']
@@ -25,7 +26,7 @@ class DummyDisplay(DisplayImpl):
         self._layout['friend_name'] = (int(width/12), int(height/10))
         self._layout['shakes'] = (0, height-int(height/25))
         self._layout['mode'] = (width-int(width/8), height - int (height/25))
-        lw, lh = fonts.Small.getbbox("W")
+        lw, lh = fonts.Small.getsize("W")
         self._layout['status'] = {
             'pos': (int(width/48), int(height/3)),
             'font': fonts.status_font(fonts.Small),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Reads the toml file in old and new format.  Also a bug fix in dummy display so it works.

## Description
<!--- Describe your changes in detail -->
made a new function to read the toml config file and used that to load the file. It loads
the contents into a string and looks for "[main]", which should exist in a properly formatted
pwnagotchi config.toml with the new format. If it does not find [main], it reads with the
toml library and converts the file to the new format, saving the old as a backup

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

New toml format is incompatible with old pwny backups.  tomlkit would endless loop on 
the old format file.

<!--- If it fixes an open issue, please link to the issue here. -->
- [ X ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
 I haven't but I will

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Developed in a live 2.9.5-3 pwny. Then checked out a new clone of jayofelony nori branch, copied the changes from the live systems.  Then I pointed the live at the new clone, and restarted pwnagotchi a few times.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X] I have signed-off my commits with `git commit -s`
