### PR TITLE
Optionally slow down or eliminate pwnagotchi.png updates. server web UI from memory instead of file

### DIFF
--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -44,6 +44,8 @@ class View(object):
         self._render_cbs = []
         self._config = config
         self._canvas = None
+        self._show_canvas = None
+        self._next_save_png = 0
         self._frozen = False
         self._lock = Lock()
         self._voice = Voice(lang=config['main']['lang'])
@@ -396,9 +398,14 @@ class View(object):
                     # lv is a ui element
                     lv.draw(self._canvas, drawer)
 
-                web.update_frame(self._canvas)
+                self._show_canvas = self._canvas.copy()
+                if time.time() > self._next_save_png:
+                    self._next_save_png = time.time() + self._config['ui'].get('png_period', 0)
+                    web.update_frame(self._canvas)
 
                 for cb in self._render_cbs:
                     cb(self._canvas)
 
                 self._state.reset()
+    def get_current_image(self):
+        return self._show_canvas.copy()

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -399,7 +399,7 @@ class View(object):
                     lv.draw(self._canvas, drawer)
 
                 self._show_canvas = self._canvas.copy()
-                if time.time() > self._next_save_png:
+                if self._config['ui'].get('png_period', 0) >= 0 and time.time() > self._next_save_png:
                     self._next_save_png = time.time() + self._config['ui'].get('png_period', 0)
                     web.update_frame(self._canvas)
 

--- a/pwnagotchi/ui/web/handler.py
+++ b/pwnagotchi/ui/web/handler.py
@@ -25,6 +25,7 @@ from flask import abort
 from flask import redirect
 from flask import render_template, render_template_string
 
+from io import BytesIO
 
 class Handler:
     def __init__(self, config, agent, app):
@@ -235,4 +236,12 @@ class Handler:
     # serve the PNG file with the display image
     def ui(self):
         with web.frame_lock:
-            return send_file(web.frame_path, mimetype='image/png')
+            try:
+                imgIO = BytesIO()
+                self._agent._view.get_current_image().save(imgIO, 'PNG')
+                imgIO.seek(0)
+                return send_file(imgIO, mimetype='image/png')
+            except Exception as e:
+                logging.error(e)
+                return send_file(web.frame_path, mimetype='image/png')
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When using larger DummyDisplay (480x720), saving the png file takes resources. Serving from memory is quicker.

## Description
<!--- Describe your changes in detail -->
Added an optional config parameter "png_period" that is the time period between saving the UI to the file in /var/tmp/pwnagotchi.  View.py stores the current UI image in a "_show_canvas" variable, and adds get_current_image(self) that returns it, making it easy for plugins to access the full UI image as ui.get_current_image().

Handler.py ui(self) gets the image using get_current_image() and serves it to flask through a BytesIO() stream instead of by file access.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Pwnagotchi UI should continue to work, even if zram gets wonky.
With large DummyDisplays, the file IO can be significant, especially with other services using the sd card (wardriver, display-password, etc).

<!--- If it fixes an open issue, please link to the issue here. -->
- [ X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on several pwnies in the no-png-file branch. This PR is just the minor changes needed to reduce the PNG updates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X ] I have signed-off my commits with `git commit -s`
