### PR TITLE
Allow rotation 90 and 270 degrees on screens

### DIFF
--- a/pwnagotchi/ui/display.py
+++ b/pwnagotchi/ui/display.py
@@ -319,7 +319,7 @@ class Display(View):
     def image(self):
         img = None
         if self._canvas is not None:
-            img = self._canvas if self._rotation == 0 else self._canvas.rotate(-self._rotation)
+            img = self._canvas if self._rotation == 0 else self._canvas.rotate(-self._rotation, expand=True)
         return img
 
     def _render_thread(self):
@@ -338,7 +338,7 @@ class Display(View):
             logging.error("%s" % e)
 
         if self._enabled:
-            self._canvas = (img if self._rotation == 0 else img.rotate(self._rotation))
+            self._canvas = (img if self._rotation == 0 else img.rotate(self._rotation, expand=True))
             if self._implementation is not None:
                 self._canvas_next = self._canvas
                 self._canvas_next_event.set()

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -49,8 +49,14 @@ class View(object):
         self._voice = Voice(lang=config['main']['lang'])
         self._implementation = impl
         self._layout = impl.layout()
-        self._width = self._layout['width']
-        self._height = self._layout['height']
+        self._rotation = config['ui']['display'].get('rotation',0)
+        if (self._rotation/90)%2 == 0:
+            self._width = self._layout['width']
+            self._height = self._layout['height']
+        else:
+            self._width = self._layout['height']
+            self._height = self._layout['width']
+
         self._state = State(state={
             'channel': LabeledValue(color=BLACK, label='CH', value='00', position=self._layout['channel'],
                                     label_font=fonts.Bold,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small modification to pwnagotchi/ui/(view.py, display.py) to support 90 and 270 degree rotations on screen.

## Description
<!--- Describe your changes in detail -->

In view.py, if rotation is 90 or 270, width and height get swapped for the pwnagotchi image.

In display.py, rotation with "expand=True" changes the dimensions of the image to fit the rotation, keeping the complete image, instead of chopping off the top and bottom.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This allows for a "vertically" oriented pwnagotchi instead of just horizontal.

<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
Will raise and issue after submitting this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on a few versions of pwnagotchi with a couple of different screen types. Since this happens at the higher level in view.py and display.py, it should work for all displays.

Tested and submitted on a jayofelony 2.9.5.3 image, with a cloned repo "git pull"ed to current code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X] I have signed-off my commits with `git commit -s`
