### PR TITLE
Add support for dynamic route metric switching in bt-tether plugin

### DIFF
--- a/pwnagotchi/cli.py
+++ b/pwnagotchi/cli.py
@@ -218,7 +218,7 @@ def pwnagotchi_cli():
                                           "[Y/N] ")
                     if pwn_bluetooth.lower() in ('y', 'yes'):
                         f.write("[main.plugins.bt-tether]\n"
-                                "enabled = true\n\n")
+                                "enabled = true\n")
                         pwn_bluetooth_phone_name = input("What name uses your phone, check settings?\n\n")
                         if pwn_bluetooth_phone_name != "":
                             f.write(f"phone-name = \"{pwn_bluetooth_phone_name}\"\n")
@@ -237,6 +237,13 @@ def pwnagotchi_cli():
                                                   "MAC: ")
                         if pwn_bluetooth_mac != "":
                             f.write(f"mac = \"{pwn_bluetooth_mac}\"\n")
+                        # add prefer-bluetooth option -- Jalopy added this
+                        pwn_bluetooth_prefer = input("Do you want to prefer Bluetooth tether over USB tether for networking?\n\n"
+                                                 "This changes the routing priority. (Y/N): ")
+                        if pwn_bluetooth_prefer.lower() in ("y", "yes"):
+                            f.write("prefer-bluetooth = true\n")
+                        else:
+                            f.write("prefer-bluetooth = false\n")
                     # set up display settings
                     pwn_display_enabled = input("Do you want to enable a display?\n\n"
                                                 "[Y/N]: ")

--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -63,6 +63,7 @@ mac = ""
 phone = "" # android or ios
 ip = "" # optional, default : 192.168.44.2 if android or 172.20.10.2 if ios
 dns = "8.8.8.8 1.1.1.1" # optional, default (google): "8.8.8.8 1.1.1.1". Consider using anonymous DNS like OpenNic :-)
+prefer-bluetooth = false # optional, set to "true" to prefer Bluetooth tethering, set to "false" to prefer USB tethering
 
 [main.plugins.fix_services]
 enabled = true

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -125,8 +125,8 @@ DNS_PTTRN = r"^\s*((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s*[ ,;]\s*)+((\d{1,3}\.\
 
 
 class BTTether(plugins.Plugin):
-    __author__ = "Jayofelony, modified my fmatray and Jalopy"
-    __version__ = "1.4"
+    __author__ = "Jayofelony, modified by fmatray and Jalopy"
+    __version__ = "1.5"
     __license__ = "GPL3"
     __description__ = "A new BT-Tether plugin"
 

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -125,7 +125,7 @@ DNS_PTTRN = r"^\s*((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s*[ ,;]\s*)+((\d{1,3}\.\
 
 
 class BTTether(plugins.Plugin):
-    __author__ = "Jayofelony, modified my fmatray"
+    __author__ = "Jayofelony, modified my fmatray and Jalopy"
     __version__ = "1.4"
     __license__ = "GPL3"
     __description__ = "A new BT-Tether plugin"
@@ -190,7 +190,9 @@ class BTTether(plugins.Plugin):
         dns = re.sub("[\s,;]+", " ", dns).strip()  # DNS cleaning
 
         try:
-            # Configure connection. Metric is set to 200 to prefer connection over USB
+	        # Configure prefered connection. Metric is set dynamically via config option to prefer either Bluetooth or USB.
+            prefer_bt = self.options.get("prefer-bluetooth", False)
+            metric = "50" if prefer_bt else "200"
             self.nmcli(
                 [
                     "connection", "modify", f"{self.phone_name}",
@@ -203,7 +205,7 @@ class BTTether(plugins.Plugin):
                     "ipv4.dns", f"{dns}",
                     "ipv4.addresses", f"{address}/24",
                     "ipv4.gateway", f"{gateway}",
-                    "ipv4.route-metric", "200",
+                    "ipv4.route-metric", f"{metric}",
                 ]
             )
             # Configure Device to autoconnect


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a new option to the bt-tether.py plugin that allows users to dynamically set the route metric for the Bluetooth connection using a prefer-bluetooth option in config.toml.

Added a prefer-bluetooth config option (defaults to false)

If prefer-bluetooth = true, Bluetooth is given a lower route metric to take priority over USB. Maintains the original behavior if the setting is not enabled. This allows choosing the preferred tethering interface without needing to manually edit metric priorities.

Allows users to SSH over USB while tethered via Bluetooth.

Added prefer-bluetooth selection to wizard

Fixed [main.plugins.bt-tether] formatting in cli.py, removed extra new line (\n) between the [main.plugins.bt-tether] header and its config options. TOML will think that it is the end of the section, so anything after it without a new header is treated as top-level.

Tested and working with both Bluetooth and USB interfaces active, system correctly prioritizes the selected route.

## Motivation and Context
This change gives users more control in how their Pwnagotchi connects to the internet. Before this change, Bluetooth tethering always received a higher route metric, making USB the preferred interface when tethered by both Bluetooth and USB. Now a config.toml option lets you switch priorities without manual editing. 

Addresses #405 

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

- Enabled and disabled prefer-bluetooth in config.toml

- Verified that the the correct metric is applied to the Bluetooth interface with "ip route; cat /etc/resolv.conf; ping -c 2 8.8.8.8; ping -c 2 google.com"

- Made sure default behavior is not affected when the option is not enabled.

- Double checked routing, DNS resolution, and SSH access over USB while Bluetooth tether is being used.

- Tested cli.py script (modified the old cli.py with old TOML parser and format so I could test on my device, but changes are basically the same other than the key name format) 

- Tested on Raspberry Pi Zero 2W running latest release 2.9.5.3

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
