### PR TITLE
fix(bt-tether): make connection discovery locale-independent and improve MAC compatibility

### DIFF
--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -154,6 +154,28 @@ class BTTether(plugins.Plugin):
     def nmcli(self, args, pattern=None):
         return self.exec_cmd("nmcli", args, pattern)
 
+    def _get_bt_connection_name(self):
+        # Get bluetooth connections that contains the phone-name
+        bt_connections = [
+            connection.split(":")[0].strip()
+            for connection
+            in self.nmcli(["-t", "-f", "NAME,TYPE", "connection", "show"]).stdout.splitlines()
+            if connection.endswith(":bluetooth") and self.options["phone-name"] in connection
+        ]
+
+        if len(bt_connections) == 1:
+            return bt_connections[0]
+        
+        if len(bt_connections) > 1:
+            # Multiple matches found: check the MAC
+            for bt_connection in bt_connections:
+                if self.nmcli(["-f", "bluetooth.bdaddr", "connection", "show", bt_connection], self.options["mac"].upper()) != -1:
+                    return bt_connection
+
+        # Fallback to the old logic
+        logging.error(f"[BT-Tether] Connection not found for {self.options['phone-name']}git")
+        return self.options["phone-name"] + " Network"
+
     def on_loaded(self):
         logging.info("[BT-Tether] plugin loaded.")
 
@@ -178,7 +200,7 @@ class BTTether(plugins.Plugin):
             logging.error(f"[BT-Tether] IP error: {address}")
             return
 
-        self.phone_name = self.options["phone-name"] + " Network"
+        self.phone_name = self._get_bt_connection_name()
         self.mac = self.options["mac"].upper()
         dns = self.options.get("dns", "8.8.8.8 1.1.1.1")
         if not re.match(DNS_PTTRN, dns):

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -179,7 +179,7 @@ class BTTether(plugins.Plugin):
             return
 
         self.phone_name = self.options["phone-name"] + " Network"
-        self.mac = self.options["mac"]
+        self.mac = self.options["mac"].upper()
         dns = self.options.get("dns", "8.8.8.8 1.1.1.1")
         if not re.match(DNS_PTTRN, dns):
             if dns == "":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves the reliability of the `bt-tether` plugin with the following changes:
- **Dynamic Connection Identification**: Replaced the hardcoded string-based lookup with a dynamic method that identifies the Bluetooth connection by filtering for device type and, if necessary (in case of multiple matches), validating against the hardware MAC address.
- **MAC Normalization**: Forced the device MAC address to uppercase to ensure compatibility with `nmcli`.
- **Fallback Strategy**: If the dynamic search finds no matches, the system falls back to the original hardcoded naming convention. This ensures that the plugin behaves exactly as it did before if the new logic cannot find a specific match.

> **Technical Note**: The new lookup function uses `self.options['mac']` directly instead of `self.mac` to avoid temporal coupling and ensure the function remains self-contained during the initialization flow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The main goal of this PR is to ensure the bt-tether plugin works correctly on systems configured with non-English locales (such as Spanish, Italian, or French).
- **Locale Issue**: Previously, the plugin [relied](https://github.com/jayofelony/pwnagotchi/blob/ff7df1f0bdc6f3611cc6b34e72a2fadacad02820/pwnagotchi/plugins/default/bt-tether.py#L181) on the hardcoded English suffix `" Network"`. Since NetworkManager uses localized names (e.g., "Rete Smartphone" in Italian, "Red Smartphone" in Spanish, "Smartphone Network" in English...), the plugin was unable to find the correct connection profile. This PR introduces a dynamic search to resolve this. Fixes #448.
- **MAC Normalization**: During testing, it was found that certain `nmcli` calls (such as [this one](https://github.com/jayofelony/pwnagotchi/blob/ff7df1f0bdc6f3611cc6b34e72a2fadacad02820/pwnagotchi/plugins/default/bt-tether.py#L210)) fail if the MAC address is provided in lowercase. Forcing the MAC to uppercase ensures compatibility across all NetworkManager commands.

<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a Raspberry Pi Zero 2 W running Pwnagotchi v2.9.5.3 and v2.9.5.4 (64-bit).
- **MAC Format**: Verified that using a lowercase MAC address in `config.toml` does not trigger "Device not found" errors in `nmcli`.
- **Locale identification**: Tested Bluetooth network identification on systems with Spanish and Italian locales, where the previous naming convention failed.
- **Ambiguity handling**: Tested with multiple Bluetooth connections sharing the same name; the plugin selected the connection matching the configured hardware MAC address.
- **Fallback**: Checked that when no matches are found, the system uses the original `"{name} Network"` convention.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
