### PR TITLE
fix: correct layout dimensions for waveshare2in13b_v3 display

### DIFF
--- a/pwnagotchi/ui/hw/waveshare2in13b_V3.py
+++ b/pwnagotchi/ui/hw/waveshare2in13b_V3.py
@@ -10,22 +10,22 @@ class Waveshare2in13bV3(DisplayImpl):
         super(Waveshare2in13bV3, self).__init__(config, 'waveshare2in13b_v3')
 
     def layout(self):
-        fonts.setup(10, 9, 10, 35, 25, 9)
-        self._layout['width'] = 250
-        self._layout['height'] = 122
-        self._layout['face'] = (0, 40)
-        self._layout['name'] = (5, 20)
+        fonts.setup(10, 8, 10, 25, 25, 9)
+        self._layout['width'] = 212
+        self._layout['height'] = 104
+        self._layout['face'] = (0, 26)
+        self._layout['name'] = (5, 15)
         self._layout['channel'] = (0, 0)
         self._layout['aps'] = (28, 0)
-        self._layout['uptime'] = (185, 0)
-        self._layout['line1'] = [0, 14, 250, 14]
-        self._layout['line2'] = [0, 108, 250, 108]
-        self._layout['friend_face'] = (0, 92)
-        self._layout['friend_name'] = (40, 94)
-        self._layout['shakes'] = (0, 109)
-        self._layout['mode'] = (225, 109)
+        self._layout['uptime'] = (147, 0)
+        self._layout['line1'] = [0, 12, 212, 12]
+        self._layout['line2'] = [0, 92, 212, 92]
+        self._layout['friend_face'] = (0, 76)
+        self._layout['friend_name'] = (40, 78)
+        self._layout['shakes'] = (0, 93)
+        self._layout['mode'] = (187, 93)
         self._layout['status'] = {
-            'pos': (125, 20),
+            'pos': (91, 15),
             'font': fonts.status_font(fonts.Medium),
             'max': 20
         }
@@ -39,8 +39,10 @@ class Waveshare2in13bV3(DisplayImpl):
         self._display.Clear()
 
     def render(self, canvasBlack=None, canvasRed=None):
+        # Match V4 behavior: if only one canvas is passed, show it on black channel
         buffer = self._display.getbuffer
-        image = Image.new('1', (self._layout['height'], self._layout['width']))
+        # Create blank image matching the display dimensions
+        image = Image.new('1', (self._layout['height'], self._layout['width']), 255)
         imageBlack = image if canvasBlack is None else canvasBlack
         imageRed = image if canvasRed is None else canvasRed
         self._display.display(buffer(imageBlack), buffer(imageRed))


### PR DESCRIPTION
The waveshare2in13b_v3 driver was using incorrect layout dimensions (250x122 copied from V4) instead of the correct V3 dimensions (212x104).

Changes:
- Fixed width from 250 to 212 and height from 122 to 104
- Adjusted all UI element positions proportionally
- Fixed Image.new() to use fill=255 (white) for proper red channel init

This resolves the issue where the screen would flicker and display all black or all red after refresh.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix issue #469 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
