### PR TITLE
Add button_feedback plugin for display status messages

### DIFF
--- a/pwnagotchi/plugins/default/button_feedback.py
+++ b/pwnagotchi/plugins/default/button_feedback.py
@@ -1,0 +1,50 @@
+import os
+import time
+import logging
+import pwnagotchi.plugins as plugins
+
+
+class ButtonFeedback(plugins.Plugin):
+    __author__ = 'CoderFX'
+    __version__ = '1.0.0'
+    __license__ = 'GPL3'
+    __description__ = 'Shows a temporary status message on the display when an external script writes to a message file. Works with PiSugar buttons, GPIO buttons, or any shell trigger.'
+
+    def __init__(self):
+        self.options = dict()
+        self._showing = False
+        self._msg = None
+        self._msg_shown_at = 0
+
+    def on_loaded(self):
+        self._message_file = self.options.get('message_file', '/tmp/.pwnagotchi-button-msg')
+        self._display_seconds = self.options.get('display_seconds', 5)
+        logging.info('[button_feedback] plugin loaded (file=%s, duration=%ds)',
+                     self._message_file, self._display_seconds)
+
+    def on_ui_update(self, ui):
+        try:
+            if os.path.exists(self._message_file):
+                if not self._showing:
+                    with open(self._message_file, 'r') as f:
+                        self._msg = f.read().strip()
+                    if self._msg:
+                        self._showing = True
+                        self._msg_shown_at = time.time()
+
+                if self._showing:
+                    if time.time() - self._msg_shown_at < self._display_seconds:
+                        ui.set('status', self._msg)
+                    else:
+                        try:
+                            os.remove(self._message_file)
+                        except OSError:
+                            pass
+                        self._showing = False
+                        self._msg = None
+            else:
+                if self._showing:
+                    self._showing = False
+                    self._msg = None
+        except Exception as e:
+            logging.debug('[button_feedback] %s', e)


### PR DESCRIPTION
## Motivation and Context

There is no built-in way for external scripts (PiSugar buttons, GPIO triggers, cron jobs) to show temporary feedback on the pwnagotchi e-ink display. Scripts that trigger actions (shutdown, mode switch, etc.) have no way to confirm the action visually.

## Description

A lightweight plugin that monitors a message file and displays its contents on the e-ink status line for a configurable duration.

**How it works:**
1. An external script writes a message: `echo "Shutting down..." > /tmp/.pwnagotchi-button-msg`
2. The plugin picks it up on the next UI update and displays it
3. After 5 seconds (configurable), the message is cleared and the file removed

**Configuration (optional):**
```toml
[main.plugins.button_feedback]
enabled = true
message_file = "/tmp/.pwnagotchi-button-msg"
display_seconds = 5
```

Works with PiSugar buttons, GPIO buttons, or any shell trigger.

## How Has This Been Tested?

- Deployed on Pi Zero 2W with Waveshare V4 e-ink
- Verified `echo "test" > /tmp/.pwnagotchi-button-msg` shows on display for 5 seconds
- Verified message clears after timeout and file is removed
- Verified no errors when file does not exist
- Verified works alongside PiSugar shutdown scripts for visual feedback