### PR TITLE
Fix whitelist not filtering passively captured handshakes

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -349,6 +349,20 @@ class Agent(Client, Automata, AsyncAdvertiser):
             filename = jmsg['data']['file']
             sta_mac = jmsg['data']['station']
             ap_mac = jmsg['data']['ap']
+
+            # Check if the AP is whitelisted before processing the handshake.
+            # get_access_points() already filters whitelisted APs from attacks,
+            # but bettercap still passively captures handshakes from all networks.
+            whitelist = set(e.lower() if isinstance(e, str) else e for e in self._config['main']['whitelist'])
+            if ap_mac.lower() in whitelist:
+                logging.debug("ignoring handshake from whitelisted AP %s", ap_mac)
+                try:
+                    os.remove(filename)
+                except OSError:
+                    pass
+                self._update_handshakes(0)
+                return
+
             key = "%s -> %s" % (sta_mac, ap_mac)
             if key not in self._handshakes:
                 self._handshakes[key] = jmsg
@@ -360,6 +374,16 @@ class Agent(Client, Automata, AsyncAdvertiser):
                     plugins.on('handshake', self, filename, ap_mac, sta_mac)
                 else:
                     (ap, sta) = ap_and_station
+                    # Also check whitelist by hostname (users may whitelist by name)
+                    if ap['hostname'].lower() in whitelist:
+                        logging.debug("ignoring handshake from whitelisted AP %s (%s)", ap['hostname'], ap_mac)
+                        try:
+                            os.remove(filename)
+                        except OSError:
+                            pass
+                        del self._handshakes[key]
+                        self._update_handshakes(0)
+                        return
                     self._last_pwnd = ap['hostname'] if ap['hostname'] != '' and ap[
                         'hostname'] != '<hidden>' else ap_mac
                     logging.warning(


### PR DESCRIPTION
## Motivation and Context

Fixes the whitelist not filtering passively captured handshakes from bettercap.

* I have raised an issue to propose this change: #499

## Description

The `main.whitelist` setting in `config.toml` is only checked in `get_access_points()`, which filters APs from **active** attacks (deauth, association). However, bettercap still **passively** captures handshakes from all nearby networks, including whitelisted ones.

When a `wifi.client.handshake` event fires, `_on_event()` in `agent.py` processes and saves the handshake without checking the whitelist. This means:

- Handshakes from the user's own home network are captured and stored
- Plugins receive `on_handshake` callbacks for whitelisted networks
- The handshake counter increments for networks the user explicitly excluded

## How Has This Been Tested?

1. Added home network SSID to `main.whitelist`
2. Ran pwnagotchi and triggered a handshake capture from the whitelisted network
3. Verified the `.pcap` file was automatically removed
4. Verified `pwnagotchi.log` shows `ignoring handshake from whitelisted AP`
5. Verified non-whitelisted handshakes still work normally

## Changes

Added whitelist filtering to `_on_event()` with two checks:

1. **By MAC address** — immediately after extracting `ap_mac`, before any processing. Catches MAC-based whitelist entries early.
2. **By hostname** — after `_find_ap_sta_in()` resolves the AP details. Catches name-based whitelist entries (SSIDs).

Uses the same whitelist format and case-insensitive comparison as `get_access_points()`. When a whitelisted handshake is detected, the `.pcap` file that bettercap already wrote to disk is removed.