### PR TITLE
Fix Fix_Services syslog handler spamming errors when bettercap is unstable

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -126,25 +126,35 @@ class FixServices(plugins.Plugin):
     def on_bcap_sys_log(self, agent, event):
         if self.is_disabled:
             return
-        if re.search('wifi error while hopping to channel', event['data']['Message']):
-            logging.debug("[Fix_Services]SYSLOG MATCH: %s" % event['data']['Message'])
-            logging.debug("[Fix_Services]**** restarting wifi.recon")
-            try:
-                result = agent.run("wifi.recon off; wifi.recon on")
-                if result["success"]:
-                    logging.debug("[Fix_Services] wifi.recon flip: success!")
-                    if hasattr(agent, 'view'):
-                        display = agent.view()
-                        if display:
-                            display.update(force=True, new_data={"status": "Wifi recon flipped!", "face": faces.COOL})
-                    else:
-                        print("Wifi recon flipped")
+        message = event.get('data', {}).get('Message', '')
+        if not isinstance(message, str):
+            return
+        if 'wifi error while hopping to channel' not in message:
+            return
+        # Cooldown: don't spam recon flips when bettercap is unstable
+        if time.time() - self.LASTTRY < 30:
+            return
+        logging.debug("[Fix_Services]SYSLOG MATCH: %s" % message)
+        logging.debug("[Fix_Services]**** restarting wifi.recon")
+        try:
+            result = agent.run("wifi.recon off; wifi.recon on")
+            if result["success"]:
+                logging.debug("[Fix_Services] wifi.recon flip: success!")
+                self.LASTTRY = time.time()
+                if hasattr(agent, 'view'):
+                    display = agent.view()
+                    if display:
+                        display.update(force=True, new_data={"status": "Wifi recon flipped!", "face": faces.COOL})
                 else:
-                    logging.warning("[Fix_Services] wifi.recon flip: FAILED: %s" % repr(result))
-                    self._tryTurningItOffAndOnAgain(agent)
-            except Exception as err:
-                logging.error("[Fix_Services]SYSLOG wifi.recon flip fail: %s" % err)
+                    print("Wifi recon flipped")
+            else:
+                logging.warning("[Fix_Services] wifi.recon flip: FAILED: %s" % repr(result))
+                self.LASTTRY = time.time()
                 self._tryTurningItOffAndOnAgain(agent)
+        except Exception as err:
+            logging.error("[Fix_Services]SYSLOG wifi.recon flip fail: %s" % err)
+            self.LASTTRY = time.time()
+            self._tryTurningItOffAndOnAgain(agent)
 
     def on_epoch(self, agent, epoch, epoch_data):
         if self.is_disabled:


### PR DESCRIPTION
## Motivation and Context

Fix_Services spams dozens of errors per minute when bettercap's wifi recon is unstable, filling the log with `TypeError` and flooding `_tryTurningItOffAndOnAgain` calls that also fail.

* I have raised an issue to propose this change: #500

## Description

`on_bcap_sys_log` fires on every bettercap syslog event matching the wifi hopping error pattern. When bettercap is in a bad state, it sends many such events per second. Each one triggers `agent.run("wifi.recon off; wifi.recon on")` which also fails because bettercap is unstable — creating a cascade: 61 `TypeError('expected string or bytes')` errors in a few minutes in observed logs.

Two root causes:

1. **No type guard on `event['data']['Message']`** — direct dict access passed into `re.search()` raises `TypeError` when Message is `None` or non-string, and `KeyError` if the event structure is unexpected.

2. **No cooldown** — unlike `on_epoch` which checks `self.LASTTRY` with a 180s cooldown, `on_bcap_sys_log` had no debounce. Every matching syslog event triggered a recon flip attempt, even if the previous one just failed.

## Changes

1. **Safe Message access**: `event.get('data', {}).get('Message', '')` with `isinstance(message, str)` check instead of direct dict access into `re.search()`.

2. **30-second cooldown**: check `self.LASTTRY` before attempting a recon flip — consistent with the debounce pattern already used in `on_epoch` and `_tryTurningItOffAndOnAgain`. Update `LASTTRY` on all outcomes (success, failure, exception) to prevent cascading retries.

## How Has This Been Tested?

1. Deployed on Pi Zero 2W with Waveshare V4 and brcmfmac onboard wifi
2. Ran pwnagotchi in auto mode during active wifi scanning
3. Verified no more error spam in `/etc/pwnagotchi/log/pwnagotchi.log` during channel hopping issues
4. Verified wifi.recon flip still triggers on first detection (not suppressed entirely)
5. Verified cooldown prevents repeated attempts within 30 seconds