### PR TITLE
fix(pisugarx): guard against None self.ps in on_loaded and on_ui_update

### DIFF
--- a/pwnagotchi/plugins/default/pisugarx.py
+++ b/pwnagotchi/plugins/default/pisugarx.py
@@ -600,9 +600,12 @@ class PiSugar(plugins.Plugin):
             f"[PiSugarX] Rotation is {'enabled' if self.rotation_enabled else 'disabled'}.")
         logging.info(
             f"[PiSugarX] Default display (when rotation disabled): {self.default_display}")
-        self.ps.lowpower_shutdown = self.options['lowpower_shutdown']
-        self.ps.lowpower_shutdown_level = self.options['lowpower_shutdown_level']
-        self.ps.max_charge_voltage_protection = self.options['max_charge_voltage_protection']
+        if self.ps is not None:
+            self.ps.lowpower_shutdown = self.options.get('lowpower_shutdown', False)
+            self.ps.lowpower_shutdown_level = self.options.get('lowpower_shutdown_level', 10)
+            self.ps.max_charge_voltage_protection = self.options.get('max_charge_voltage_protection', False)
+        else:
+            logging.warning("[PiSugarX] PiSugar not connected during on_loaded, skipping config")
 
     def on_ready(self, agent):
         try:
@@ -811,11 +814,13 @@ class PiSugar(plugins.Plugin):
             capacity = 0
             voltage = 0.00
             temp = 0
-            logging.info(f"[PiSugarX] PiSugar is not ready")
+            logging.debug("[PiSugarX] PiSugar is not ready")
 
-        # Check if battery is plugged in
-        battery_plugged = self.safe_get(
-            self.ps.get_battery_power_plugged, default=False)
+        # Check if battery is plugged in (only when ready and ps is available)
+        battery_plugged = False
+        if self.ready and self.ps is not None:
+            battery_plugged = self.safe_get(
+                self.ps.get_battery_power_plugged, default=False)
 
         if battery_plugged:
             # If plugged in, display "CHG"


### PR DESCRIPTION
## Summary
- Guard `self.ps` access in `on_loaded` with None check and use `.get()` with safe defaults
- Move `battery_plugged` check in `on_ui_update` inside the `self.ready` guard with `self.ps is not None` check
- Downgrade "PiSugar is not ready" log from `info` to `debug` to reduce log spam during normal operation

Without these guards, the plugin crashes with `AttributeError` when PiSugar hardware is not connected or temporarily unavailable.

Fixes #507