### PR TITLE
fix(pisugarx): prevent double voltage append with charge protection

### DIFF
--- a/pwnagotchi/plugins/default/pisugarx.py
+++ b/pwnagotchi/plugins/default/pisugarx.py
@@ -184,8 +184,9 @@ class PiSugarServer:
                     else:
                         self.set_battery_allow_charging()
 
-                self.voltage_history.append(self.battery_voltage)
-                self.battery_level = self.convert_battery_voltage_to_level()
+                if self.model == 'PiSugar3' or not self.max_charge_voltage_protection:
+                    self.voltage_history.append(self.battery_voltage)
+                    self.battery_level = self.convert_battery_voltage_to_level()
 
                 if self.lowpower_shutdown:
                     if self.battery_level < self.lowpower_shutdown_level:


### PR DESCRIPTION
## Summary
- Fix double append to `voltage_history` for PiSugar2/2Plus when `max_charge_voltage_protection` is enabled
- Each voltage reading was counted twice per cycle, skewing the trimmed-mean battery level calculation
- Make the unconditional append conditional: only for PiSugar3 or when charge protection is off

Fixes #509