### PR TITLE
fix(fix_services): fix "interfaceface" typo in log message

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -386,7 +386,7 @@ class FixServices(plugins.Plugin):
                                     break
                                 else:
                                     logging.debug(
-                                        "[Fix_Services set wifi.interfaceface wlan0mon] failed? %s" % repr(result))
+                                        "[Fix_Services set wifi.interface wlan0mon] failed? %s" % repr(result))
                             except Exception as err:
                                 logging.debug(
                                     "[Fix_Services set wifi.interface wlan0mon] except: %s" % repr(err))


### PR DESCRIPTION
Closes #516

Fix typo: `wifi.interfaceface` → `wifi.interface` in the debug log output.