### PR TITLE
fix(fix_services): remove unused Popen in on_ready

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -105,8 +105,6 @@ class FixServices(plugins.Plugin):
     def on_ready(self, agent):
         if self.is_disabled:
             return
-        last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
-                                                                 stdout=subprocess.PIPE).stdout))[-10:])
         try:
             cmd_output = subprocess.check_output("ip link show wlan0mon", shell=True)
             logging.debug("[Fix_Services ip link show wlan0mon]: %s" % repr(cmd_output))


### PR DESCRIPTION
Closes #518

Remove the unused `last_lines` Popen + TextIOWrapper in `on_ready` that leaks a file descriptor every startup.