### PR TITLE
fix(fix_services): remove dead code in on_ui_setup

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -453,15 +453,6 @@ class FixServices(plugins.Plugin):
     def on_ui_setup(self, ui):
         if self.is_disabled:
             return
-        with ui._lock:
-            # add custom UI elements
-            if "position" in self.options:
-                pos = self.options['position'].split(',')
-                pos = [int(x.strip()) for x in pos]
-            else:
-                pos = (ui.width() / 2 + 35, ui.height() - 11)
-
-            logging.debug("Got here")
 
     # called when the ui is updated
     def on_ui_update(self, ui):


### PR DESCRIPTION
Closes #520

Remove unused `pos` computation, `ui._lock` context, and debug placeholder in `on_ui_setup`.