### PR TITLE
fix(fix_services): fix bettercap result success checks

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -138,7 +138,7 @@ class FixServices(plugins.Plugin):
         logging.debug("[Fix_Services]**** restarting wifi.recon")
         try:
             result = agent.run("wifi.recon off; wifi.recon on")
-            if result["success"]:
+            if result.get("success"):
                 logging.debug("[Fix_Services] wifi.recon flip: success!")
                 self.LASTTRY = time.time()
                 if hasattr(agent, 'view'):
@@ -190,7 +190,7 @@ class FixServices(plugins.Plugin):
 
                 try:
                     result = agent.run("wifi.recon off; wifi.recon on")
-                    if result["success"]:
+                    if result.get("success"):
                         logging.debug("[Fix_Services] wifi.recon flip: success!")
                         if display:
                             display.update(force=True, new_data={"status": "Wifi recon flipped!",
@@ -252,7 +252,7 @@ class FixServices(plugins.Plugin):
                 logging.debug("[Fix_Services] Monitor mode failed!")
                 try:
                     result = agent.run("wifi.recon off; wifi.recon on")
-                    if result["success"]:
+                    if result.get("success"):
                         logging.debug("[Fix_Services] wifi.recon flip: success!")
                         if display:
                             display.update(force=True, new_data={"status": "Wifi recon flipped!",
@@ -330,7 +330,7 @@ class FixServices(plugins.Plugin):
 
             try:
                 result = connection.run("wifi.recon off")
-                if "success" in result:
+                if result.get("success"):
                     self.logPrintView("info", "[Fix_Services] wifi.recon off: %s!" % repr(result),
                                       display, {"status": "Wifi recon paused!", "face": faces.COOL})
                     time.sleep(2)
@@ -380,7 +380,7 @@ class FixServices(plugins.Plugin):
                             try:
                                 # try accessing mon0 in bettercap
                                 result = connection.run("set wifi.interface wlan0mon")
-                                if "success" in result:
+                                if result.get("success"):
                                     logging.debug("[Fix_Services set wifi.interface wlan0mon worked!")
                                     # stop looping and get back to recon
                                     break
@@ -432,7 +432,7 @@ class FixServices(plugins.Plugin):
             try:
                 result = connection.run("wifi.clear; wifi.recon on")
 
-                if "success" in result:  # and result["success"] is True:
+                if result.get("success"):
                     if display:
                         display.update(force=True, new_data={"status": "I can see again! (probably)",
                                                              "face": faces.HAPPY})


### PR DESCRIPTION
Closes #524

Change all `"success" in result` and `result["success"]` to `result.get("success")` for correct boolean checking.