### PR TITLE
fix(fix_services): replace os.system with subprocess.run

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -235,7 +235,7 @@ class FixServices(plugins.Plugin):
                 if hasattr(agent, 'view'):
                     display.set('status', 'Restarting pwnagotchi!')
                     display.update(force=True)
-                os.system("systemctl restart bettercap")
+                subprocess.run(["systemctl", "restart", "bettercap"], timeout=30)
                 pwnagotchi.restart("AUTO")
 
             # Look for pattern 6
@@ -244,7 +244,7 @@ class FixServices(plugins.Plugin):
                 if hasattr(agent, 'view'):
                     display.set('status', 'Restarting pwnagotchi!')
                     display.update(force=True)
-                os.system("systemctl restart bettercap")
+                subprocess.run(["systemctl", "restart", "bettercap"], timeout=30)
                 pwnagotchi.restart("AUTO")
 
             # Look for pattern 7


### PR DESCRIPTION
## Summary
- Replace 2 `os.system()` calls with `subprocess.run()` using list-form args
- Adds 30-second timeout to prevent indefinite hangs
- Avoids unnecessary shell invocation

Closes #537

Signed-off-by: PwnPacker <4704376+CoderFX@users.noreply.github.com>