### PR TITLE
fix(fix_services): remove unused imports Text, BLACK, fonts

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -12,9 +12,6 @@ from pwnagotchi import plugins
 import pwnagotchi.ui.faces as faces
 from pwnagotchi.bettercap import Client
 
-from pwnagotchi.ui.components import Text
-from pwnagotchi.ui.view import BLACK
-import pwnagotchi.ui.fonts as fonts
 
 
 class FixServices(plugins.Plugin):


### PR DESCRIPTION
## Summary
- Remove unused imports: `Text`, `BLACK`, `fonts`
- These have zero references in the file

Closes #536

Signed-off-by: PwnPacker <4704376+CoderFX@users.noreply.github.com>