### PR TITLE
fix(fix_services): update LASTTRY cooldown after pattern matches

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -174,6 +174,7 @@ class FixServices(plugins.Plugin):
 
             logging.debug("[Fix_Services]**** checking")
             if len(self.pattern.findall(last_lines)) >= 1:
+                self.LASTTRY = time.time()
                 subprocess.check_output("monstop", shell=True)
                 subprocess.check_output("monstart", shell=True)
                 display.set('status', 'Wifi channel stuck. Restarting recon.')
@@ -182,6 +183,7 @@ class FixServices(plugins.Plugin):
 
             # Look for pattern 2
             elif len(self.pattern2.findall(other_last_lines)) >= 5:
+                self.LASTTRY = time.time()
                 logging.debug("[Fix_Services]**** Should trigger a reload of the wlan0mon device:\n%s" % last_lines)
                 if hasattr(agent, 'view'):
                     display.set('status', 'Wifi channel stuck. Restarting recon.')
@@ -205,6 +207,7 @@ class FixServices(plugins.Plugin):
 
             # Look for pattern 3
             elif len(self.pattern3.findall(other_last_lines)) >= 1:
+                self.LASTTRY = time.time()
                 logging.debug("[Fix_Services] Firmware has halted or crashed. Restarting wlan0mon.")
                 if hasattr(agent, 'view'):
                     display.set('status', 'Firmware has halted or crashed. Restarting wlan0mon.')
@@ -218,6 +221,7 @@ class FixServices(plugins.Plugin):
 
             # Look for pattern 4
             elif len(self.pattern4.findall(other_other_last_lines)) >= 3:
+                self.LASTTRY = time.time()
                 logging.debug("[Fix_Services] wlan0 is down!")
                 if hasattr(agent, 'view'):
                     display.set('status', 'Restarting wlan0 now!')
@@ -249,6 +253,7 @@ class FixServices(plugins.Plugin):
 
             # Look for pattern 7
             elif len(self.pattern7.findall(other_other_last_lines)) >= 1:
+                self.LASTTRY = time.time()
                 logging.debug("[Fix_Services] Monitor mode failed!")
                 try:
                     result = agent.run("wifi.recon off; wifi.recon on")


### PR DESCRIPTION
## Summary
When a recovery action fires, the cooldown timer now gets updated so the device has time to stabilize before attempting another recovery. Without this, a device experiencing intermittent issues can get stuck in a restart loop — recovering, immediately detecting the same issue again, and recovering again in a tight cycle.

- Patterns 1, 2, 3, 4, and 7 now set `LASTTRY = time.time()` before attempting recovery
- Patterns 5 and 6 restart the whole process so they don't need this

Closes #538

Signed-off-by: PwnPacker <4704376+CoderFX@users.noreply.github.com>