### PR TITLE
fix(fix_services): replace Popen/check_output with safe _run_cmd helper

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -3,7 +3,6 @@ import re
 import subprocess
 import time
 import random
-from io import TextIOWrapper
 import os
 
 import pwnagotchi
@@ -37,17 +36,23 @@ class FixServices(plugins.Plugin):
         self.isReloadingMon = False
         self.connection = None
         self.LASTTRY = 0
+        self.SUBPROCESS_TIMEOUT = 30
         self.is_disabled = self._check_external_adapter()
 
-    def _check_external_adapter(self): 
+    def _run_cmd(self, cmd, timeout=None):
+        """Run a command safely with list args and timeout, returning stdout as string."""
+        if timeout is None:
+            timeout = self.SUBPROCESS_TIMEOUT
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout).stdout
+
+    def _check_external_adapter(self):
         """
         Check if an external WiFi adapter is being used instead of the onboard brcmfmac chip.
         Returns True if external adapter detected (plugin should be disabled), False otherwise.
         """
         try:
             # Check if wlan0 interface exists and get its driver
-            cmd_output = subprocess.check_output("ls /sys/class/net/", shell=True, text=True)
-            interfaces = cmd_output.strip().split('\n')
+            interfaces = os.listdir('/sys/class/net/')
             
             # Look for wlan0 interface
             if 'wlan0' in interfaces:
@@ -68,8 +73,8 @@ class FixServices(plugins.Plugin):
                             logging.info("[Fix_Services] Onboard brcmfmac detected. Plugin will remain active.")
                             return False
                     else:
-                        lsmod_output = subprocess.check_output("lsmod | grep brcmfmac", shell=True, text=True)
-                        if lsmod_output.strip():
+                        lsmod_output = self._run_cmd(['lsmod'])
+                        if 'brcmfmac' in lsmod_output:
                             logging.info("[Fix_Services] brcmfmac module detected via lsmod. Plugin will remain active.")
                             return False
                         else:
@@ -103,7 +108,7 @@ class FixServices(plugins.Plugin):
         if self.is_disabled:
             return
         try:
-            cmd_output = subprocess.check_output("ip link show wlan0mon", shell=True)
+            cmd_output = self._run_cmd(['ip', 'link', 'show', 'wlan0mon'])
             logging.debug("[Fix_Services ip link show wlan0mon]: %s" % repr(cmd_output))
             if ",UP," in str(cmd_output):
                 logging.debug("wlan0mon is up.")
@@ -154,13 +159,9 @@ class FixServices(plugins.Plugin):
     def on_epoch(self, agent, epoch, epoch_data):
         if self.is_disabled:
             return
-        last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
-                                                                 stdout=subprocess.PIPE).stdout))[-10:])
-        other_last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10'],
-                                                                       stdout=subprocess.PIPE).stdout))[-10:])
-        other_other_last_lines = ''.join(
-            list(TextIOWrapper(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
-                                                stdout=subprocess.PIPE).stdout))[-10:])
+        last_lines = self._run_cmd(['journalctl', '-n10', '-k'])
+        other_last_lines = self._run_cmd(['journalctl', '-n10'])
+        other_other_last_lines = self._run_cmd(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'])
         # don't check if we ran a reset recently
         logging.debug("[Fix_Services]**** epoch")
         if time.time() - self.LASTTRY > 180:
@@ -170,8 +171,8 @@ class FixServices(plugins.Plugin):
             logging.debug("[Fix_Services]**** checking")
             if len(self.pattern.findall(last_lines)) >= 1:
                 self.LASTTRY = time.time()
-                subprocess.check_output("monstop", shell=True)
-                subprocess.check_output("monstart", shell=True)
+                self._run_cmd(['monstop'])
+                self._run_cmd(['monstart'])
                 display.set('status', 'Wifi channel stuck. Restarting recon.')
                 display.update(force=True)
                 pwnagotchi.restart("AUTO")
@@ -209,7 +210,7 @@ class FixServices(plugins.Plugin):
                     display.update(force=True)
                 try:
                     # Run the monstart command to restart wlan0mon
-                    cmd_output = subprocess.check_output("monstart", shell=True)
+                    cmd_output = self._run_cmd(['monstart'])
                     logging.debug("[Fix_Services monstart]: %s" % repr(cmd_output))
                 except Exception as err:
                     logging.error("[Fix_Services monstart]: %s" % repr(err))
@@ -223,7 +224,7 @@ class FixServices(plugins.Plugin):
                     display.update(force=True)
                 try:
                     # Run the monstart command to restart wlan0mon
-                    cmd_output = subprocess.check_output("monstart", shell=True)
+                    cmd_output = self._run_cmd(['monstart'])
                     logging.debug("[Fix_Services monstart]: %s" % repr(cmd_output))
                 except Exception as err:
                     logging.error("[Fix_Services monstart]: %s" % repr(err))
@@ -234,7 +235,7 @@ class FixServices(plugins.Plugin):
                 if hasattr(agent, 'view'):
                     display.set('status', 'Restarting pwnagotchi!')
                     display.update(force=True)
-                subprocess.run(["systemctl", "restart", "bettercap"], timeout=30)
+                self._run_cmd(['systemctl', 'restart', 'bettercap'])
                 pwnagotchi.restart("AUTO")
 
             # Look for pattern 6
@@ -243,7 +244,7 @@ class FixServices(plugins.Plugin):
                 if hasattr(agent, 'view'):
                     display.set('status', 'Restarting pwnagotchi!')
                     display.update(force=True)
-                subprocess.run(["systemctl", "restart", "bettercap"], timeout=30)
+                self._run_cmd(['systemctl', 'restart', 'bettercap'])
                 pwnagotchi.restart("AUTO")
 
             # Look for pattern 7
@@ -315,7 +316,7 @@ class FixServices(plugins.Plugin):
             # attempt a sanity check. does wlan0mon exist?
             # is it up?
             try:
-                cmd_output = subprocess.check_output("ip link show wlan0mon", shell=True)
+                cmd_output = self._run_cmd(['ip', 'link', 'show', 'wlan0mon'])
                 logging.debug("[Fix_Services ip link show wlan0mon]: %s" % repr(cmd_output))
                 if ",UP," in str(cmd_output):
                     logging.debug("wlan0mon is up. Skip reset?")
@@ -342,7 +343,7 @@ class FixServices(plugins.Plugin):
             logging.debug("[Fix_Services] recon paused. Now trying wlan0mon reload")
 
             try:
-                cmd_output = subprocess.check_output("monstop", shell=True)
+                cmd_output = self._run_cmd(['monstop'])
                 self.logPrintView("info", "[Fix_Services] wlan0mon down and deleted: %s" % cmd_output,
                                   display, {"status": "wlan0mon d-d-d-down!", "face": faces.BORED})
             except Exception as nope:
@@ -359,20 +360,20 @@ class FixServices(plugins.Plugin):
             while tries < 3:
                 try:
                     # unload the module
-                    cmd_output = subprocess.check_output("sudo modprobe -r brcmfmac", shell=True)
+                    cmd_output = self._run_cmd(['sudo', 'modprobe', '-r', 'brcmfmac'])
                     self.logPrintView("info", "[Fix_Services] unloaded brcmfmac", display,
                                       {"status": "Turning it off #%s" % tries, "face": faces.SMART})
 
                     # reload the module
                     try:
                         # reload the brcmfmac kernel module
-                        cmd_output = subprocess.check_output("sudo modprobe brcmfmac", shell=True)
+                        cmd_output = self._run_cmd(['sudo', 'modprobe', 'brcmfmac'])
 
                         self.logPrintView("info", "[Fix_Services] reloaded brcmfmac")
 
                         # success! now make the mon0
                         try:
-                            cmd_output = subprocess.check_output("monstart", shell=True)
+                            cmd_output = self._run_cmd(['monstart'])
                             self.logPrintView("info", "[Fix_Services interface add wlan0mon worked #%s: %s"
                                               % (tries, cmd_output))
                             try:


### PR DESCRIPTION
## Summary
Every epoch, fix_services spawns multiple subprocesses (journalctl, tail, monstop, monstart, modprobe) using bare Popen and check_output with shell=True. This causes three problems that hit especially hard on long-running 24/7 devices:

1. **File descriptor leaks** — Popen objects are never closed, so each epoch leaks FDs until the OS limit is reached
2. **No timeout** — if modprobe or monstart hangs during a driver issue, the plugin blocks forever and the pwnagotchi stops scanning
3. **shell=True overhead** — every command spawns an extra /bin/sh process

This PR adds a `_run_cmd()` helper that uses `subprocess.run()` with list-form arguments and a 30-second timeout, then replaces all bare subprocess calls with it. The TextIOWrapper import is also removed since it's no longer needed.

Closes #541

Signed-off-by: PwnPacker <4704376+CoderFX@users.noreply.github.com>