### PR TITLE
feat(fix_services): defer log reads until cooldown expires

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -154,16 +154,17 @@ class FixServices(plugins.Plugin):
     def on_epoch(self, agent, epoch, epoch_data):
         if self.is_disabled:
             return
-        last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
-                                                                 stdout=subprocess.PIPE).stdout))[-10:])
-        other_last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10'],
-                                                                       stdout=subprocess.PIPE).stdout))[-10:])
-        other_other_last_lines = ''.join(
-            list(TextIOWrapper(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
-                                                stdout=subprocess.PIPE).stdout))[-10:])
         # don't check if we ran a reset recently
         logging.debug("[Fix_Services]**** epoch")
         if time.time() - self.LASTTRY > 180:
+            # Only read logs when cooldown has expired (avoids 3 subprocess calls per epoch)
+            last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
+                                                                     stdout=subprocess.PIPE).stdout))[-10:])
+            other_last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10'],
+                                                                           stdout=subprocess.PIPE).stdout))[-10:])
+            other_other_last_lines = ''.join(
+                list(TextIOWrapper(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
+                                                    stdout=subprocess.PIPE).stdout))[-10:])
             # get last 10 lines
             display = agent.view() if hasattr(agent, 'view') else None
 


### PR DESCRIPTION
## Summary
- Move 3 subprocess calls (journalctl x2, tail) inside the 180s cooldown check
- Previously spawned 3 subprocesses every epoch (~10s) even during cooldown
- Now only reads logs when pattern matching will actually occur
- Reduces unnecessary CPU/memory pressure on Pi Zero

## Test plan
- [ ] Verify pattern detection still works after cooldown expires
- [ ] Confirm no subprocess calls during cooldown period (check with strace or debug logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)