### PR TITLE
feat(fix_services): add interface name validation helper

### DIFF
--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -25,6 +25,15 @@ class FixServices(plugins.Plugin):
     Automatically disables itself when an external WiFi adapter is detected instead of the onboard brcmfmac chip.
     """
 
+    _IFACE_RE = re.compile(r'^[a-zA-Z0-9_-]{1,15}$')
+
+    @classmethod
+    def _validate_iface(cls, name):
+        """Validate a Linux network interface name."""
+        if not cls._IFACE_RE.match(name):
+            raise ValueError('Invalid interface name: %r' % name)
+        return name
+
     def __init__(self):
         self.options = dict()
         self.pattern = re.compile(r'ieee80211 phy0: brcmf_cfg80211_add_iface: iface validation failed: err=-95')
@@ -103,6 +112,7 @@ class FixServices(plugins.Plugin):
         if self.is_disabled:
             return
         try:
+            self._validate_iface("wlan0mon")
             cmd_output = subprocess.check_output("ip link show wlan0mon", shell=True)
             logging.debug("[Fix_Services ip link show wlan0mon]: %s" % repr(cmd_output))
             if ",UP," in str(cmd_output):


### PR DESCRIPTION
## Summary
- Add `_IFACE_RE` regex and `_validate_iface()` classmethod
- Validates Linux interface names (max 15 chars, `[a-zA-Z0-9_-]`)
- Called before `ip link show wlan0mon` in `on_ready`
- Safety net if interface names are ever externalized to config

## Test plan
- [ ] Verify plugin loads normally (hardcoded names pass validation)
- [ ] Confirm ValueError raised for invalid names like `../etc/passwd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)