### PR TITLE
Fix AttributeError in wpa-sec plugin when skipping failed uploads

### DIFF
--- a/pwnagotchi/plugins/default/wpa-sec.py
+++ b/pwnagotchi/plugins/default/wpa-sec.py
@@ -125,7 +125,7 @@ class WpaSec(plugins.Plugin):
                             
                         except requests.exceptions.RequestException:
                             logging.exception("WPA_SEC: RequestException uploading %s, skipping until reload.", handshake)
-                            self.skip_until_reload.append(handshake)
+                            self.skip_until_reload.add(handshake)
                         except OSError:
                             logging.exception("WPA_SEC: OSError uploading %s, deleting from db.", handshake)
                             cursor.execute('DELETE FROM handshakes WHERE path = ?', (handshake,))


### PR DESCRIPTION
## Description
`skip_until_reload` is initialized as a `set`, but `on_internet_available` called `.append()` on it, which sets don't support. Changed to `.add()`.

## Motivation and Context
Any failed handshake upload (e.g. transient DNS/network failure) would raise an `AttributeError` when the plugin tried to mark it as skip-until-reload, crashing the event handler and masking the original upload error in the logs.

- [x] I have raised an issue to propose this change (required)

## How Has This Been Tested?
Reproduced the crash on a live unit by triggering an upload failure (DNS not yet resolvable after bt-tether connection), confirmed the `AttributeError` in logs, applied the fix, and confirmed subsequent failed uploads are added to `skip_until_reload` without crashing and the original `RequestException` is now logged cleanly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the CONTRIBUTING guide
- [ ] I have signed-off my commits with `git commit -s`