### PR TITLE
fix(ohcapi): apply main.whitelist and stop sending the removed receive_email field

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -75,7 +75,6 @@ orientation = "horizontal"
 [main.plugins.ohcapi]
 enabled = false
 api_key = "sk_your_api_key_here"
-receive_email = "yes"
 
 [main.plugins.pwndroid]
 enabled = false

--- a/pwnagotchi/plugins/default/ohcapi.py
+++ b/pwnagotchi/plugins/default/ohcapi.py
@@ -4,13 +4,13 @@ import requests
 import time
 from datetime import datetime
 from threading import Lock
-from pwnagotchi.utils import StatusFile
+from pwnagotchi.utils import StatusFile, remove_whitelisted
 import pwnagotchi.plugins as plugins
 from json.decoder import JSONDecodeError
 
 class ohcapi(plugins.Plugin):
     __author__ = 'Rohan Dayaram'
-    __version__ = '1.2.0'
+    __version__ = '1.2.1'
     __license__ = 'GPL3'
     __description__ = 'Uploads WPA/WPA2 handshakes to OnlineHashCrack.com using the new API (V2), no dashboard.'
 
@@ -36,9 +36,6 @@ class ohcapi(plugins.Plugin):
             logging.error(f"OHC NewAPI: Missing required config fields: {missing}")
             return
 
-        if 'receive_email' not in self.options:
-            self.options['receive_email'] = 'yes'  # default
-            
         if 'sleep' not in self.options:
             self.options['sleep'] = 60*60  # default to 1 hour
 
@@ -137,6 +134,9 @@ class ohcapi(plugins.Plugin):
             handshake_paths = [os.path.join(handshake_dir, filename)
                                 for filename in handshake_filenames if filename.endswith('.pcapng')]
 
+            # Never upload the user's own networks to a third-party cracking service.
+            handshake_paths = remove_whitelisted(handshake_paths, config['main']['whitelist'])
+
             # A .pcapng can keep growing after it was reported (bettercap appends newly
             # captured EAPOLs/PMKIDs for the same AP/station), so track size and reprocess
             # files that have grown since we last uploaded them, not just brand new ones.
@@ -221,8 +221,7 @@ class ohcapi(plugins.Plugin):
             'agree_terms': "yes",
             'action': 'add_tasks',
             'algo_mode': 22000,
-            'hashes': clean_hashes,
-            'receive_email': self.options['receive_email']
+            'hashes': clean_hashes
         }
 
         try:
@@ -234,7 +233,13 @@ class ohcapi(plugins.Plugin):
             logging.info(f"OHC NewAPI: Add tasks response: {data}")
             return True
         except requests.exceptions.RequestException as e:
-            logging.debug(f"OHC NewAPI: Exception while adding tasks -> {e}")
+            # The API returns the reason in the response body; without it a 400 is
+            # indistinguishable from any other failure.
+            body = getattr(getattr(e, 'response', None), 'text', None)
+            if body:
+                logging.error(f"OHC NewAPI: Exception while adding tasks -> {e} | Response: {body}")
+            else:
+                logging.error(f"OHC NewAPI: Exception while adding tasks -> {e}")
             return False
 
     def _extract_hashes_from_handshake(self, pcap_path):


### PR DESCRIPTION
Fixes #596 and #595, both of which you invited a PR for.

### 1. `main.whitelist` was never applied (#596)

`_run_tasks()` built the pcapng list straight from `os.listdir()` and uploaded everything it found. Networks the user had explicitly whitelisted were converted to `.22000` and sent to onlinehashcrack.com.

`wpa-sec`, the other plugin that ships data off the device, filters through `utils.remove_whitelisted()` first. `ohcapi` now does the same, at the point where the path list is built:

```python
handshake_paths = remove_whitelisted(handshake_paths, config['main']['whitelist'])
```

Verified against `remove_whitelisted()` directly: with `whitelist = ["ale-IoT", "aleiPhone17pro"]`, the matching handshakes are dropped and unrelated ones are kept; an empty whitelist keeps everything, so existing setups are unaffected.

### 2. `_add_tasks` always failed with HTTP 400 (#595)

The payload still carried `receive_email`, which the v2 API no longer accepts:

```json
{"success":false,"error_code":"unknown_field",
 "message":"Unknown field(s): receive_email","unknown":["receive_email"]}
```

Removed from the payload, from the `on_loaded()` default, and from `defaults.toml`.

The failure was also invisible: the handler logged only `str(e)` at `debug`, so with default logging the plugin silently uploaded nothing. It now logs the response body at `error`, which is what made the field name findable in the first place.

### Note on #594

@BraedenP232 independently reported the `receive_email` 400 in #594 two days before #595, and said they had fixes ready pending confirmation. This PR overlaps with them on that one point only.

I have deliberately left the other three items from #594 alone so they remain theirs to submit: the missing `self.lock` check in `on_ui_update`, the `self.skip` list permanently excluding handshakes after a failed upload, and the wrong path in the `JSONDecodeError` recovery branch of `__init__`. Happy to fold any of them in here instead if you would rather have one PR.

Tested on a Pi Zero 2W running 2.9.5.6.
