### PR TITLE
fix(bt-tether): strip trailing colon from the PAN interface name

### DIFF
--- a/pwnagotchi/bluetooth/network.py
+++ b/pwnagotchi/bluetooth/network.py
@@ -28,9 +28,12 @@ class NetworkManager:
             )
             for line in result.stdout.split("\n"):
                 if "bnep" in line or "bt-pan" in line:
-                    match = re.search(r"(\d+):\s+(\S+)", line)
+                    # `ip link show` prints "3: bnep0: <BROADCAST,...>", so \S+ would
+                    # capture the trailing colon. Exclude ':' and '@' so both "bnep0:"
+                    # and altname forms like "bnep0@if3" yield a usable interface name.
+                    match = re.search(r"^\d+:\s+([^:@\s]+)", line)
                     if match:
-                        return match.group(2)
+                        return match.group(1)
         except Exception as e:
             self.logger.debug(f"Failed to get interface name: {e}")
         return None


### PR DESCRIPTION
Fixes #593.

`NetworkManager.get_interface_name()` matched `(\d+):\s+(\S+)` against `ip link show`, whose output is

```
3: bnep0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN ...
```

so `\S+` captured `bnep0:` with the trailing colon. That value goes straight to `ping -I`:

```
ping: invalid source address: bnep0:
Connected via bnep0 but no internet access
```

The tether itself was fine — PAN up, DHCP done, traffic flowing — only the check reported failure.

The pattern is now anchored and excludes `:` and `@`:

```python
match = re.search(r"^\d+:\s+([^:@\s]+)", line)
```

Checked against real `ip link show` lines:

| input | before | after |
|---|---|---|
| `3: bnep0: <BROADCAST,...>` | `bnep0:` | `bnep0` |
| `5: bnep0@if3: <BROADCAST,...>` | `bnep0@if3:` | `bnep0` |
| `4: bt-pan: <BROADCAST,...>` | `bt-pan:` | `bt-pan` |

Excluding `@` also covers altname forms, which the old pattern would have mangled too.

`get_pan_interface()` further down the same file already did this correctly via `line.split(":")`; the two functions do the same job and could be collapsed, but I kept this PR to the bug.

Reproduced and verified on a Pi Zero 2W running 2.9.5.6, tethered to an iPhone.
