### PR TITLE
fix(pisugarx): cut power after the shutdown finishes, and read the level from 0x2A

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -89,6 +89,7 @@ rotation = false
 default_display = "percentage"
 lowpower_shutdown = true
 lowpower_shutdown_level = 10 # battery percent at which the device will turn off
+shutdown_delay = 45 # seconds before the PiSugar cuts power, must outlast the shutdown
 max_charge_voltage_protection = false #It will limit the battery voltage to about 80% to extend battery life
 
 [main.plugins.pwncrack]

--- a/pwnagotchi/plugins/default/pisugarx.py
+++ b/pwnagotchi/plugins/default/pisugarx.py
@@ -64,6 +64,7 @@ class PiSugarServer:
         self.allow_charging = True
         self.lowpower_shutdown = False
         self.lowpower_shutdown_level = 10
+        self.shutdown_delay = 45
         self.max_charge_voltage_protection = False
         self.max_protection_level=80
         # Start the device connection in a background thread
@@ -185,7 +186,13 @@ class PiSugarServer:
                         self.set_battery_allow_charging()
 
                 self.voltage_history.append(self.battery_voltage)
-                self.battery_level = self.convert_battery_voltage_to_level()
+                if self.model == 'PiSugar3':
+                    # The MCU reports the percentage itself in 0x2A. The voltage
+                    # curve is only needed for the PiSugar 2 chips, which have no
+                    # such register.
+                    self.battery_level = self.i2creg[0x2A]
+                else:
+                    self.battery_level = self.convert_battery_voltage_to_level()
 
                 if self.lowpower_shutdown:
                     if self.battery_level < self.lowpower_shutdown_level:
@@ -200,13 +207,15 @@ class PiSugarServer:
     def shutdown(self):
         # logging.info("[PiSugarX] PiSugar set shutdown .")
         if self.model == 'PiSugar3':
-            # Shutdown the power after 10 seconds
+            # Cut the rail after shutdown_delay seconds. Ten was not enough:
+            # pwnagotchi.shutdown() sleeps exactly that long refreshing the display
+            # before it even starts syncing the zram mounts to the SD card.
             self._bus.write_byte_data(self.address, 0x0B, 0x29)  # Disable write protection
-            self._bus.write_byte_data(self.address, 0x09, 10)
+            self._bus.write_byte_data(self.address, 0x09, self.shutdown_delay)
             self._bus.write_byte_data(self.address, 0x02, self._bus.read_byte_data(
                 self.address, 0x02) & 0b11011111)
             self._bus.write_byte_data(self.address, 0x0B, 0x00)  # Enable write protection
-            logging.info("[PiSugarX] PiSugar shutdown in 10s.")
+            logging.info(f"[PiSugarX] PiSugar shutdown in {self.shutdown_delay}s.")
         elif self.model == 'PiSugar2':
             pass
         elif self.model == 'PiSugar2Plus':
@@ -603,6 +612,7 @@ class PiSugar(plugins.Plugin):
         self.ps.lowpower_shutdown = self.options['lowpower_shutdown']
         self.ps.lowpower_shutdown_level = self.options['lowpower_shutdown_level']
         self.ps.max_charge_voltage_protection = self.options['max_charge_voltage_protection']
+        self.ps.shutdown_delay = int(cfg.get('shutdown_delay', 45))
 
     def on_ready(self, agent):
         try:


### PR DESCRIPTION
Two independent problems in the PiSugar 3 path, both found while wiring a PiSugar 3 to a Zero 2 W.

### The power cut can land in the middle of the sync

`shutdown()` arms the delayed cut with a hardcoded 10 seconds and then hands over to `pwnagotchi.shutdown()`:

```python
self.shutdown()
pwnagotchi.shutdown()
```

But `pwnagotchi.shutdown()` spends exactly that long refreshing the display before it starts doing anything durable:

```python
    view.ROOT.on_shutdown()
    # give it some time to refresh the ui
    time.sleep(10)
    ...
    os.system("sync")
    os.system("halt")
```

So the countdown expires just as the zram mounts start being rsynced to the SD card, with `halt` and the systemd teardown still to come. Measured on a Zero 2 W, `syncing...` is logged 10.02 s after `shutting down ...`, leaving nothing for the rest.

The delay is now `shutdown_delay`, defaulting to 45. A longer delay only costs a few tens of milliamperes for a few extra seconds on a board that has already halted, which is not worth optimising against a corrupted card. The vendor's own example script uses 30.

### The battery percentage is recomputed although the MCU reports it

`update_value()` ends with the voltage curve for every model:

```python
    self.voltage_history.append(self.battery_voltage)
    self.battery_level = self.convert_battery_voltage_to_level()
```

On PiSugar 3 that discards a value the hardware already provides. The [I2C datasheet](https://docs.pisugar.com/docs/product-wiki/battery/pisugar3/pisugar-3-i2c) documents `0x2A` as "The proportion of electricity (0-100%)", and the plugin is in fact already reading the whole register block, so no extra traffic is involved. Other PiSugar 3 plugins in the wild use it directly.

The curve is left in place for PiSugar 2 and 2 Plus, which have no such register.

### Testing

Both on a PiSugar 3, firmware v1.3.8, Zero 2 W, Waveshare 2.13 v3.

- with `shutdown_delay = 45`, the blue LED goes out after the halt completes rather than during the sync
- `0x2A` matches what `pisugar-power-manager` reports, and no longer wanders while the reading settles