### PR TITLE
fix(web): messages are never marked as read

### DIFF
--- a/pwnagotchi/ui/web/templates/message.html
+++ b/pwnagotchi/ui/web/templates/message.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %} {% set active_page = "" %} {% block title %} Message
-from {{ message.sender_name }} {% endblock %} {% block script %} // Mark message
-as read fetch('/inbox/{{ message.id }}/seen') .then(res => res.text())
-.then(data => console.log('Message marked as read')); {% endblock %} {% block
+from {{ message.sender_name }} {% endblock %} {% block script %}
+// Mark message as read
+fetch('/inbox/{{ message.id }}/seen')
+  .then(res => res.text())
+  .then(data => console.log('Message marked as read'));
+{% endblock %} {% block
 content %}
 <div class="card">
   <div class="card-header">


### PR DESCRIPTION
Opening a message from the web inbox does not mark it as read.

`base.html` drops the block straight into a `<script>` tag:

```html
    <script>
      {% block script %}{% endblock %}
    </script>
```

and `message.html` supplies it like this:

```
{% block script %} // Mark message
as read fetch('/inbox/{{ message.id }}/seen') .then(res => res.text())
.then(data => console.log('Message marked as read')); {% endblock %}
```

which renders as:

```javascript
 // Mark message
as read fetch('/inbox/14576/seen') .then(res => res.text())
.then(data => console.log('Message marked as read'));
```

`//` comments to the end of the line, so the statement begins with `as read fetch(...)`. That is a syntax error, the whole `<script>` element fails to parse, and the fetch never fires. It looks like a formatter reflowed the block at some point and joined the comment with the code.

The consequence is that `seen_at` stays `null` no matter how many times a message is opened, so anything counting unread mail keeps counting it. The only way to clear it today is by hand:

```
curl -s http://127.0.0.1:8666/api/v1/inbox/<id>/seen
```

The fix just puts the comment on its own line.

### Testing

On 2.9.5.6: before the change, opening a message from the web UI leaves `"seen_at": null` in `GET /api/v1/inbox` and the browser console reports a syntax error. After it, `seen_at` is filled in and the console logs `Message marked as read`.