### PR TITLE
fix(grid): advertise(False) requests a malformed path

### DIFF
--- a/pwnagotchi/grid.py
+++ b/pwnagotchi/grid.py
@@ -37,7 +37,7 @@ def call(path, obj=None):
 
 
 def advertise(enabled=True):
-    return call("/mesh/%s" % 'true' if enabled else 'false')
+    return call("/mesh/%s" % ('true' if enabled else 'false'))
 
 
 def set_advertisement_data(data):


### PR DESCRIPTION
`grid.advertise(False)` cannot turn advertising off.

```python
def advertise(enabled=True):
    return call("/mesh/%s" % 'true' if enabled else 'false')
```

`%` binds tighter than the conditional expression, so this parses as:

```python
    call(("/mesh/%s" % 'true') if enabled else 'false')
```

The true branch is fine. The false branch passes the bare string `'false'` as the path, so `call()` builds:

```
http://127.0.0.1:8666/api/v1false
```

which is a 404 and raises out of `call()`. Only `advertise(True)` has ever done anything.

```python
>>> enabled = False
>>> "/mesh/%s" % 'true' if enabled else 'false'
'false'
>>> "/mesh/%s" % ('true' if enabled else 'false')
'/mesh/false'
```

Nothing in the tree calls it with `False` today, so the bug is invisible in normal operation. It surfaces as soon as a plugin wants to stop advertising at runtime, which is a reasonable thing to want: `personality.advertise` is only read once, in `start_advertising()`, so the config flag cannot be used for that after startup.

The fix is a pair of parentheses.