### PR TITLE
fix(bt-tether): status display latches onto the first device seen

### DIFF
--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -142,13 +142,17 @@ class BtTether(Plugin):
                             connected_device = device
                             break
 
-            # If no status for stored MAC, look for any connected device with NAP (tethering)
-            if not cached_status:
+            # Look for a connected device with NAP when the stored MAC has none.
+            # A paired but absent device still answers with a status dict, so
+            # testing the dict alone latches onto the first device ever seen and
+            # keeps reporting it after tethering moved to another one.
+            if not cached_status or not cached_status.get("connected", False):
                 trusted_devices = self.bt.connection.get_trusted_devices()
                 for device in trusted_devices:
                     if device.connected and device.has_nap:
-                        cached_status = self.bt.connection.get_full_status(device.mac)
-                        if cached_status:
+                        status = self.bt.connection.get_full_status(device.mac)
+                        if status:
+                            cached_status = status
                             self.phone_mac = device.mac
                             self._phone_name = device.name
                             connected_device = device


### PR DESCRIPTION
The on-screen indicator stops reflecting reality as soon as more than one device can provide tethering.

## What happens

`on_ui_update()` reads the status of the stored MAC, then falls back to scanning the trusted devices:

```python
if not cached_status:
    trusted_devices = self.bt.connection.get_trusted_devices()
    for device in trusted_devices:
        if device.connected and device.has_nap:
            cached_status = self.bt.connection.get_full_status(device.mac)
```

`get_full_status()` returns a dict for any paired device, including one that is switched off or out of range: `connected` is simply `False` inside it. So once `self.phone_mac` has been set, `not cached_status` is false forever and the scan never runs a second time.

## Why it matters

With one phone this is invisible. With a second host offering NAP it is not: the plugin latches onto whichever device it saw first and keeps reporting that one. When the connection moves elsewhere, the indicator shows `P` (paired, not connected) while tethering is up and working through another device, which is exactly the moment the display is supposed to be useful.

Found on a unit that reaches the network through either a desktop or a phone over Bluetooth PAN, depending on where it is. The `C` was correct for the first host and stayed wrong afterwards.

## The change

Rescan when the stored device reports itself disconnected, rather than only when it returns nothing.

The scan result goes into a temporary and is copied over `cached_status` only on success, so a scan that finds no connected device leaves the previous status in place. Without that, a rescan finding nothing would drop the status entirely and the display would lose the distinction between `P` and `X`.

No configuration change, no new option, and the single-device case behaves exactly as before.