### PR TITLE
fix(auto_backup): startup log always claims a 60 minute interval

### DIFF
--- a/pwnagotchi/plugins/default/auto_backup.py
+++ b/pwnagotchi/plugins/default/auto_backup.py
@@ -112,7 +112,7 @@ class AutoBackup(plugins.Plugin):
             else ""
         )
         logging.info(
-            f"AUTO-BACKUP: Plugin loaded for host '{self.hostname}'. Interval: 60min, Backups kept: {self.max_backups}{include_msg}"
+            f"AUTO-BACKUP: Plugin loaded for host '{self.hostname}'. Interval: {self.interval_seconds // 60}min, Backups kept: {self.max_backups}{include_msg}"
         )
 
     def is_backup_due(self):


### PR DESCRIPTION
The startup line hardcodes the interval while interpolating everything else around it:

```python
f"AUTO-BACKUP: Plugin loaded for host '{self.hostname}'. Interval: 60min, Backups kept: {self.max_backups}{include_msg}"
```

`interval_seconds` is read from the config and used by `is_backup_due()`, so the schedule itself is correct. Only the message is wrong, and it is wrong in the way that costs time: 60 minutes is exactly `DEFAULT_INTERVAL_SECONDS`, so the line reads true on a default install and starts lying the moment someone sets the option.

Noticed on a unit configured with `interval_seconds = 21600`. The log announced `Interval: 60min` while the archives were six hours apart, which is the sort of contradiction that sends you looking for a scheduling bug that does not exist.

Interpolating the configured value is the whole change.