### PR TITLE
fix: persistent auto-mode restart loop on Pi Zero W (ARMv6) — 4 stacked fixes

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -446,8 +446,21 @@ class Agent(Client, Automata, AsyncAdvertiser):
                 return m['running']
         return False
 
-    def start_module(self, module):
-        self.run('%s on' % module)
+     def start_module(self, module):
+        import time as _time
+        last_err = None
+        for attempt in range(5):
+            try:
+                self.run('%s on' % module)
+                return
+            except Exception as err:
+                last_err = err
+                if 'Interface Not Up' in str(err):
+                    logging.warning("[start_module] %s not up yet, retrying (%d/5)..." % (module, attempt + 1))
+                    _time.sleep(2)
+                    continue
+                raise
+        raise last_err
 
     def restart_module(self, module):
         self.run('%s off; %s on' % (module, module))

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -176,6 +176,7 @@ class FixServices(plugins.Plugin):
                 subprocess.check_output("monstart", shell=True)
                 display.set('status', 'Wifi channel stuck. Restarting recon.')
                 display.update(force=True)
+                self.LASTTRY = time.time()
                 pwnagotchi.restart("AUTO")
 
             # Look for pattern 2

--- a/stage3/06-patches/files/pwnagotchi-launcher
+++ b/stage3/06-patches/files/pwnagotchi-launcher
@@ -10,8 +10,9 @@ if is_crypted_mode; then
 fi
 
 if is_auto_mode; then
-  /opt/.pwn/bin/pwnagotchi
   systemctl restart bettercap
+  sleep 3
+  /opt/.pwn/bin/pwnagotchi
 else
   /opt/.pwn/bin/pwnagotchi --manual
 fi

--- a/stage3/06-patches/files/pwnlib
+++ b/stage3/06-patches/files/pwnlib
@@ -110,10 +110,21 @@ start_monitor_interface() {
     return 1
   fi
 
-  ifconfig wlan0 down
-  ifconfig wlan0mon up
-  iw dev wlan0mon set power_save off
-  return 0
+ifconfig wlan0 down
+ifconfig wlan0mon up
+
+local up_timeout=10
+while ! is_interface_up wlan0mon && [ "$up_timeout" -gt 0 ]; do
+  sleep 0.3
+  up_timeout=$((up_timeout - 1))
+done
+if ! is_interface_up wlan0mon; then
+  echo "start_monitor_interface: wlan0mon did not reach UP state" >&2
+  return 1
+fi
+
+iw dev wlan0mon set power_save off
+return 0
 }
 
 # stops mon0
@@ -128,10 +139,7 @@ stop_monitor_interface() {
 
 # returns 0 if the specified network interface is up
 is_interface_up() {
-  if grep -qi 'up' /sys/class/net/"$1"/operstate; then
-    return 0
-  fi
-  return 1
+  ip link show "$1" 2>/dev/null | grep -q '<[^>]*,UP,'
 }
 
 # returns 0 if conditions for AUTO mode are met


### PR DESCRIPTION
Fixes #606 

## Summary

On Raspberry Pi Zero W (ARMv6, `brcmfmac`/BCM43430), `auto` mode restarted
the pwnagotchi service every 60–90 seconds, indefinitely. Three stacked
root causes were hiding each other — fixing each one exposed the next.
Full analysis with logs in the linked issue.

Session length after all fixes: from a ~85s restart loop to continuous
runs of 390 and 343 epochs (~5h37m / ~4h45m), zero restarts.

## Changes

1. **`stage3/06-patches/files/pwnlib`** — `is_interface_up()` read
   `operstate`, which never reports `up` for monitor-mode interfaces
   (stays `unknown` even when `ip link` shows `UP,LOWER_UP`); it now
   checks the actual interface flags. `start_monitor_interface()` also
   returned immediately after `ifconfig wlan0mon up`; it now waits
   (bounded) for the interface to actually reach UP, so bettercap's next
   request can't hit it half-up on slow SDIO.

2. **`stage3/06-patches/files/pwnagotchi-launcher`** — restart bettercap
   *before* starting pwnagotchi, not after. bettercap.service opens
   `wlan0mon` once at its own startup and keeps that handle; every
   pwnagotchi restart recreates `wlan0mon` (new ifindex), so the old
   order guaranteed `Interface Not Up` on every cycle.

3. **`pwnagotchi/agent.py`** — `start_module()` retries (bounded,
   5 × 2s) when the error is the transient `Interface Not Up`; anything
   else is re-raised immediately. Defense in depth — observed firing
   on-device during recovery.

4. **`pwnagotchi/plugins/default/fix_services.py`** — the `pattern1`
   branch never updated `self.LASTTRY`, so the 180s cooldown gate never
   engaged for it and it could restart the agent on every epoch while
   the matching kernel line stayed in the last 10 `journalctl -k` lines.

## Tested on

Pi Zero W (ARMv6), pwnagotchi v2.9.5.5:
- Before: restart every ~85s, 447× `Interface Not Up` in the log,
  websocket re-created every ~60s before the process died.
- After: two continuous runs of 390 and 343 epochs, zero restarts,
  single websocket session per run.
- One transient `Interface Not Up` during the final run was caught and
  survived — the case change #3 covers.