### PR TITLE
fix(agent): start_module is indented one space too far, breaking every startup

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -446,7 +446,7 @@ class Agent(Client, Automata, AsyncAdvertiser):
                 return m['running']
         return False
 
-     def start_module(self, module):
+    def start_module(self, module):
         import time as _time
         last_err = None
         for attempt in range(5):


### PR DESCRIPTION
### The problem

On `noai` (and in the `v2.9.5.7` release), `Agent.start_module()` is indented with five spaces instead of four:

```
$ sed -n '449p' pwnagotchi/agent.py | cat -A
     def start_module(self, module):$
```

That makes the whole module unparseable:

```
$ python3 -m py_compile pwnagotchi/agent.py
Sorry: IndentationError: unindent does not match any outer indentation level (agent.py, line 449)
```

`pwnagotchi/agent.py` is imported on every startup path, so nothing runs. It is not visible from `import pwnagotchi` (which does not pull in `agent.py`), and because `/usr/bin/pwnagotchi-launcher` is a bash script that keeps going after Python dies and exits 0, the failure shows up in the journal as a clean exit rather than a traceback.

Anyone who upgrades an existing install to `v2.9.5.7` — including via the `auto-update` plugin, which does `pip install` of the release archive — ends up with a device that no longer starts.

### The fix

One space. The retry loop added around `self.run('%s on' % module)` is untouched.

### Verified

`python3 -m py_compile` passes on the patched file, and `python3 -m compileall` is clean across the installed package. Running on a Pi Zero 2W (`v2.9.5.7`, patched in place before this PR): agent starts, plugins load, no traceback.
