### PR TITLE
Show plugin descriptions in Web UI for disabled plugins

### DIFF
--- a/pwnagotchi/plugins/__init__.py
+++ b/pwnagotchi/plugins/__init__.py
@@ -4,6 +4,7 @@ import glob
 import _thread
 import threading
 import importlib, importlib.util
+import ast
 import logging
 import time
 import prctl
@@ -216,6 +217,29 @@ def load_from_path(path, enabled=()):
                 logging.debug(e, exc_info=True)
 
     return loaded
+
+
+def get_plugin_metadata(filepath):
+    """
+    Statically parse a plugin's source file to extract __description__, __author__,
+    and __version__ without importing/enabling it.
+    """
+    metadata = {'__description__': None, '__author__': None, '__version__': None}
+    try:
+        with open(filepath, 'rt', errors='ignore') as f:
+            source = f.read()
+        tree = ast.parse(source, filename=filepath)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                for stmt in node.body:
+                    if isinstance(stmt, ast.Assign):
+                        for target in stmt.targets:
+                            if isinstance(target, ast.Name) and target.id in metadata:
+                                if isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, str):
+                                    metadata[target.id] = stmt.value.value
+    except Exception as e:
+        logging.debug("could not statically parse plugin metadata from %s: %s" % (filepath, e))
+    return metadata
 
 
 def load(config):

--- a/pwnagotchi/ui/web/handler.py
+++ b/pwnagotchi/ui/web/handler.py
@@ -221,11 +221,25 @@ class Handler:
             for plugin_name, plugin_path in plugins.database.items():
                 if plugin_path.startswith(default_path):
                     default_plugins.add(plugin_name)
+
+            plugin_info = {}
+            for plugin_name, plugin_path in plugins.database.items():
+                instance = plugins.loaded.get(plugin_name)
+                if instance is not None:
+                    plugin_info[plugin_name] = {
+                        '__description__': getattr(instance, '__description__', None),
+                        '__author__': getattr(instance, '__author__', None),
+                        '__version__': getattr(instance, '__version__', None),
+                    }
+                else:
+                    plugin_info[plugin_name] = plugins.get_plugin_metadata(plugin_path)
+
             return render_template(
                 "plugins.html",
                 loaded=plugins.loaded,
                 database=plugins.database,
                 default_plugins=default_plugins,
+                plugin_info=plugin_info,
             )
 
         if name == "toggle" and request.method == "POST":

--- a/pwnagotchi/ui/web/templates/plugins.html
+++ b/pwnagotchi/ui/web/templates/plugins.html
@@ -2,8 +2,8 @@
 title%}Plugins{% endblock %} {% block styles %}{{ super() }}{% endblock %} {%
 block script %}{% endblock %} {% block content %}
 <div id="container">
-  {% for name in database.keys() | sort %} {% set has_info = name in loaded and
-  loaded[name].__description__ is defined %}
+  {% for name in database.keys() | sort %} {% set has_info =
+  plugin_info[name]['__description__'] %}
   <div class="plugins-box">
     <div class="tooltip">
       <div class="plugin-header">
@@ -12,13 +12,13 @@ block script %}{% endblock %} {% block content %}
           <a href="/plugins/{{ name | urlencode }}">{{ name }}</a>
           {% else %}{{ name }}{% endif %}
         </h4>
-        {% if name in loaded and loaded[name].__version__ is defined %}
-        <span class="badge version">{{ loaded[name].__version__ }}</span>
+        {% if plugin_info[name]['__version__'] %}
+        <span class="badge version">{{ plugin_info[name]['__version__'] }}</span>
         {% endif %}
       </div>
       <div class="author">
-        {% if name in loaded and loaded[name].__author__ is defined %} {{
-        loaded[name].__author__ }} {% endif %}
+        {% if plugin_info[name]['__author__'] %} {{
+        plugin_info[name]['__author__'] }} {% endif %}
       </div>
       <div class="plugin-badges">
         {% if name in default_plugins %}
@@ -26,7 +26,7 @@ block script %}{% endblock %} {% block content %}
         {% endif %}
       </div>
       {% if has_info %}
-      <span class="tooltiptext">{{ loaded[name].__description__ }}</span>
+      <span class="tooltiptext">{{ plugin_info[name]['__description__'] }}</span>
       {% else %}
       <span class="tooltiptext">Description unable to load yet.</span>
       {% endif %}


### PR DESCRIPTION
## Summary
- The Plugins page tooltip showed "Description unable to load yet." for any disabled plugin because `handler.py`'s `plugins()` view only read metadata off `plugins.loaded`, which only contains instantiated (enabled) plugin objects.
- Added `plugins.get_plugin_metadata()`, which statically parses a plugin's source file with `ast` to pull `__description__`/`__author__`/`__version__` without importing/enabling it.
- `handler.py` now builds a unified `plugin_info` dict (live instance for enabled plugins, static parse for disabled ones) and `plugins.html` reads description/author/version from it. The enable/disable checkbox and `on_webhook` link stay tied to `loaded`, unchanged.

Fixes #613

## Test plan
- [x] Verified `ast`-based extraction against all 22 default plugins (including `gpio_buttons`, called out in the issue) — correct description/author/version for each, no parse errors.
- [ ] Manually load `/plugins` in the Web UI and confirm disabled plugins now show their tooltip/badges on hover, and that toggling enable/disable still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)