### PR TITLE
fix(bt-tether): dhcpcd fast-path hangs 20s and fails the connect

### DIFF
--- a/pwnagotchi/bluetooth/network.py
+++ b/pwnagotchi/bluetooth/network.py
@@ -17,7 +17,7 @@ class NetworkManager:
     # DHCP tuning
     DHCP_RELEASE_WAIT = 1
     DHCP_KILL_WAIT = 0.5
-    DHCPCD_FAST_CONF = "/tmp/bt-tether-dhcpcd.conf"
+    DHCP_TIMEOUT = 15
     DHCLIENT_FAST_CONF = "/tmp/bt-tether-dhclient.conf"
 
     def __init__(self, logger=None, options=None):
@@ -199,50 +199,67 @@ class NetworkManager:
 
             if has_dhcpcd:
                 self.logger.info("Using dhcpcd...")
-                # Release any existing lease first
-                subprocess.run(
-                    ["sudo", "dhcpcd", "-k", iface],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    timeout=5,
-                )
+                # Stop any dhcpcd already on this interface so we start clean
+                try:
+                    subprocess.run(
+                        ["sudo", "dhcpcd", "-k", iface],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=5,
+                    )
+                except subprocess.TimeoutExpired:
+                    pass
                 time.sleep(self.DHCP_RELEASE_WAIT)
-                # dhcpcd ARP-probes the address for ~5-6s (duplicate-address
-                # detection). That's pointless on a point-to-point Bluetooth PAN
-                # link, so disable it via a minimal config - it's the single
-                # biggest chunk of connect time. Skipped when fast_dhcp is off.
-                cf_args = []
-                if self.fast_dhcp:
-                    try:
-                        with open(self.DHCPCD_FAST_CONF, "w") as cf:
-                            cf.write("noarp\n")
-                        cf_args = ["-f", self.DHCPCD_FAST_CONF]
-                    except Exception as e:
-                        self.logger.debug(f"dhcpcd cf write failed: {e}")
-                # Request new lease
-                result = subprocess.run(
-                    ["sudo", "dhcpcd", "-4"] + cf_args + ["-n", iface],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    timeout=20,
-                )
-                # If our noarp config made dhcpcd unhappy (unusual version), retry
-                # once with a plain invocation so we still get a lease anywhere.
-                if result.returncode != 0 and cf_args:
-                    self.logger.info("dhcpcd config rejected - retrying without noarp tuning")
-                    result = subprocess.run(
-                        ["sudo", "dhcpcd", "-4", "-n", iface],
+
+                # -b: background immediately rather than blocking until a lease.
+                #     dhcpcd keeps the lease renewed as a daemon and we poll for
+                #     the address separately (wait_for_interface_ip), so this call
+                #     cannot hang the connect thread.
+                # -A (--noarp): skip the ~5-6s duplicate-address ARP probe, which
+                #     is pointless on a point-to-point PAN link.
+                # NB: do NOT use `-f <config>` + `-n` - that replaces dhcpcd's whole
+                #     config and hangs against a running privsep dhcpcd (9/10), which
+                #     is what caused the 20s "DHCP setup error" timeouts.
+                fast_args = ["-A"] if self.fast_dhcp else []
+
+                def _run_dhcpcd(extra):
+                    return subprocess.run(
+                        ["sudo", "dhcpcd", "-4", "-b"] + extra + [iface],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                         text=True,
-                        timeout=20,
+                        timeout=self.DHCP_TIMEOUT,
                     )
+
+                result = None
+                try:
+                    result = _run_dhcpcd(fast_args)
+                except subprocess.TimeoutExpired:
+                    self.logger.warning("dhcpcd timed out - clearing and retrying plain")
+                    try:
+                        subprocess.run(
+                            ["sudo", "dhcpcd", "-k", iface],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            timeout=5,
+                        )
+                    except Exception:
+                        pass
+
+                # Fall back to a plain run on a timeout, or if the fast flag was rejected
+                if result is None or (result.returncode != 0 and fast_args):
+                    if result is not None:
+                        self.logger.info("dhcpcd rejected fast options - retrying plain")
+                    try:
+                        result = _run_dhcpcd([])
+                    except subprocess.TimeoutExpired:
+                        self.logger.error("dhcpcd timed out on plain retry")
+                        return False
+
                 if result.stdout.strip():
                     self.logger.info(f"dhcpcd: {result.stdout.strip()}")
-                if result.returncode == 0:
-                    dhcp_success = True
-                else:
+                dhcp_success = result.returncode == 0
+                if not dhcp_success:
                     self.logger.warning(f"dhcpcd failed: {result.stderr.strip()}")
 
             elif has_dhclient:


### PR DESCRIPTION
## Problem
On dhcpcd 10 (privsep), tethering fails with:

```
[ERROR] connect_thread : DHCP setup error: Command
'['sudo', 'dhcpcd', '-4', '-f', '/tmp/bt-tether-dhcpcd.conf', '-n', 'bnep0']'
timed out after 20 seconds
```

The `fast_dhcp` path wrote a `noarp` config and ran `dhcpcd -f <file> -n bnep0`.
`-f` replaces dhcpcd's entire config, and combined with `-n` (rebind) against the
running dhcpcd daemon it hangs to the 20s cap. That raises
`subprocess.TimeoutExpired`, which the returncode-only fallback never caught, so
DHCP failed and the whole connect failed.

## Fix
In the dhcpcd branch of `NetworkManager._setup_dhclient_internal()`:
- **`-b` (background immediately)** instead of blocking until a lease. dhcpcd is
  designed to run as a daemon and renew the lease for the life of the tether; the
  address is picked up by the existing `wait_for_interface_ip()` poll, so the call
  can no longer hang the connect thread.
- Keep the ARP-probe skip via the **`-A`/`--noarp` flag** rather than a `-f`
  config file, so it doesn't replace dhcpcd's config or fight the daemon.
- **Timeout-safe with a real fallback**: catch `TimeoutExpired`, clear the
  interface, and retry plain; keep the rejected-flag fallback. A hang can no
  longer fail the connect outright. Add a `DHCP_TIMEOUT` constant; drop the unused
  `DHCPCD_FAST_CONF`. The dhclient path is unchanged.

## Testing
Verified on a Pi with dhcpcd 10.1.0: `dhcpcd -4 -b -A bnep0` returns in ~80ms
(was 20s), and the connect sequence completes cleanly — `Network setup
successful` → `Internet connectivity verified`, tether gets a lease, no timeout.