### PR TITLE
fix(bt-tether): self-heal bluetooth restart times out at 5s, so recovery never completes

### DIFF
--- a/pwnagotchi/bluetooth/__init__.py
+++ b/pwnagotchi/bluetooth/__init__.py
@@ -333,16 +333,24 @@ class BluetoothService:
                             if self.connection._consecutive_busy >= self.connection.RECOVER_BUSY_THRESHOLD:
                                 with self._lock:
                                     self._message = "Bluetooth busy - recovering..."
-                                if self._recover_bluetooth():
+                                outcome = self._recover_bluetooth()
+                                if outcome == "recovered":
                                     nap_connected = self.connection.connect_nap(mac)
                                     if nap_connected:
                                         break
-                                    # We only get here after repeated br-connection-busy
-                                    # (a controller-side wedge). If a bluetooth restart
-                                    # still can't reconnect - whatever the error now - the
-                                    # stack is wedged in a way only a power-cycle clears.
+                                    # A restart completed but the connect still fails
+                                    # -> wedged in a way only a power-cycle clears.
                                     self._handle_bt_stuck()
                                     break
+                                elif outcome == "failed":
+                                    # The restart itself couldn't complete (e.g. bluetooth
+                                    # hung on stop) - the controller is badly wedged, so
+                                    # escalate straight to the power-cycle path.
+                                    self._handle_bt_stuck()
+                                    break
+                                # "rate_limited": restarted very recently - don't hammer
+                                # or reboot-loop; let the monitor's backoff retry later.
+                                break
 
                 if nap_connected:
                     self.logger.info("NAP connection successful!")
@@ -444,11 +452,14 @@ class BluetoothService:
         """Clear a wedged controller (repeated br-connection-busy): restart the
         Bluetooth stack and re-register the pairing agent.
 
-        Rate-limited so a persistent fault can't turn into a restart loop.
+        Rate-limited so a persistent fault can't turn into a restart loop. Returns
+        one of: "recovered" (restart completed, controller responsive),
+        "failed" (restart couldn't complete - controller badly wedged, only a
+        power-cycle will clear it), or "rate_limited" (restarted too recently).
         """
         now = time.time()
         if now - self._last_recover_time < self.RECOVER_MIN_INTERVAL:
-            return False
+            return "rate_limited"
         self._last_recover_time = now
 
         self.logger.warning("Repeated br-connection-busy - recovering the Bluetooth stack")
@@ -469,7 +480,7 @@ class BluetoothService:
             self.connection.set_device_name(pwnagotchi.name())
         except Exception:
             pass
-        return ok
+        return "recovered" if ok else "failed"
 
     def _handle_bt_stuck(self):
         """A bluetooth restart did NOT clear the busy wedge - the controller is

--- a/pwnagotchi/bluetooth/connection.py
+++ b/pwnagotchi/bluetooth/connection.py
@@ -39,6 +39,9 @@ class ConnectionManager:
     # wedged and only a bluetooth restart clears it.
     RECOVER_BUSY_THRESHOLD = 3
     BLUETOOTH_RESTART_TIMEOUT = 15
+    # `systemctl restart bluetooth` on a wedged controller can take well over 5s
+    # (bluetoothd hangs on stop until systemd's stop timeout), so give it room.
+    BLUETOOTH_RESTART_CMD_TIMEOUT = 30
 
     def __init__(self, logger=None, options=None):
         self.logger = logger or logging.getLogger(__name__)
@@ -145,9 +148,11 @@ class ConnectionManager:
                 ["systemctl", "restart", "bluetooth"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
-                timeout=self.SUBPROCESS_TIMEOUT_STANDARD,
+                timeout=self.BLUETOOTH_RESTART_CMD_TIMEOUT,
             )
         except Exception as e:
+            # A restart that can't even complete means the controller is badly
+            # wedged - only a power-cycle will clear it. Signal that to the caller.
             self.logger.warning(f"Failed to restart bluetooth: {e}")
             return False
 


### PR DESCRIPTION
## Problem
The busy self-heal (`force_restart_bluetooth`) runs `systemctl restart bluetooth`
with a **5s** timeout. On a wedged controller that restart takes longer, so it
times out and fails — **289 times in a single session's log**:

```
Failed to restart bluetooth: Command '['systemctl', 'restart', 'bluetooth']'
timed out after 5 seconds
```

Consequences:
- The recovery restart never completes, so the controller stays wedged and the
  connect falls into the 5-fail → **300s cooldown blackout** instead of healing.
- Because `force_restart_bluetooth()` returns `False`, `_recover_bluetooth()`
  returns `False`, so the **stuck-reboot escalation never fires** either.

## Fix
- Give `systemctl restart bluetooth` a dedicated **`BLUETOOTH_RESTART_CMD_TIMEOUT`
  (30s)** instead of the 5s `SUBPROCESS_TIMEOUT_STANDARD`, so the restart can
  actually complete.
- `_recover_bluetooth()` now returns a tri-state — **recovered / failed /
  rate_limited**. A `failed` restart (couldn't complete → controller badly
  wedged) escalates to `_handle_bt_stuck()` → the opt-in power-cycle, instead of
  silently doing nothing. `rate_limited` still backs off so it can't reboot-loop.

## Context
This is the recovery path added in #609; the 5s timeout made it a no-op in
practice on combo chips (brcmfmac) where a bluetooth restart under load takes
>5s. It does not stop the drops themselves (WiFi/BT coexistence — `hci0: command
tx timeout` / ACL desync); it makes a wedge self-heal in ~seconds instead of a
multi-minute outage.

## Testing
Verified on a Pi (dhcpcd 10.1.0, brcmfmac): with the 30s timeout the bluetooth
restart completes and the tether recovers in place; the fix loads cleanly and
reconnects.