### PR TITLE
bt-tether: half-open PAN watchdog, layered controller recovery + web-UI diagnostics

### DIFF
--- a/pwnagotchi/bluetooth/__init__.py
+++ b/pwnagotchi/bluetooth/__init__.py
@@ -73,6 +73,9 @@ class BluetoothService:
         # Wedged-controller ("stuck") tracking: set only when a bluetooth restart
         # did NOT clear the busy state (distinct from "phone tethering off").
         self._bt_stuck = False
+        # True while the recovery ladder is actively resetting Bluetooth, so the
+        # display can say "Healing..." instead of a confusing Paired/Connected.
+        self._healing = False
         self._connected_since_boot = False
 
         # Scan state tracking
@@ -482,24 +485,30 @@ class BluetoothService:
         self._last_recover_time = now
 
         self.logger.warning(f"Recovering the Bluetooth stack ({reason})")
+        with self._lock:
+            self._healing = True
         try:
-            self.agent.stop()
-        except Exception as e:
-            self.logger.debug(f"Agent stop during recovery failed: {e}")
+            try:
+                self.agent.stop()
+            except Exception as e:
+                self.logger.debug(f"Agent stop during recovery failed: {e}")
 
-        ok = self.connection.force_restart_bluetooth()
+            ok = self.connection.force_restart_bluetooth()
 
-        # The restart drops the agent's bluetoothctl session - bring it back up
-        try:
-            self.agent.start()
-        except Exception as e:
-            self.logger.debug(f"Agent restart during recovery failed: {e}")
-        try:
-            import pwnagotchi
-            self.connection.set_device_name(pwnagotchi.name())
-        except Exception:
-            pass
-        return "recovered" if ok else "failed"
+            # The restart drops the agent's bluetoothctl session - bring it back up
+            try:
+                self.agent.start()
+            except Exception as e:
+                self.logger.debug(f"Agent restart during recovery failed: {e}")
+            try:
+                import pwnagotchi
+                self.connection.set_device_name(pwnagotchi.name())
+            except Exception:
+                pass
+            return "recovered" if ok else "failed"
+        finally:
+            with self._lock:
+                self._healing = False
 
     def _handle_bt_stuck(self):
         """A bluetooth daemon restart did NOT clear the busy wedge. Escalate:
@@ -525,22 +534,27 @@ class BluetoothService:
 
         self._last_module_reload_time = now
         with self._lock:
+            self._healing = True
             self._message = "Bluetooth wedged - reloading module..."
         # The reload restarts bluetooth, dropping the agent's bluetoothctl
         # session - stop it first, bring it back after.
         try:
-            self.agent.stop()
-        except Exception as e:
-            self.logger.debug(f"Agent stop during module reload failed: {e}")
+            try:
+                self.agent.stop()
+            except Exception as e:
+                self.logger.debug(f"Agent stop during module reload failed: {e}")
 
-        recovered = self.connection.reload_bt_module()
+            recovered = self.connection.reload_bt_module()
 
-        try:
-            self.agent.start()
-            import pwnagotchi
-            self.connection.set_device_name(pwnagotchi.name())
-        except Exception as e:
-            self.logger.debug(f"Agent/name restore after module reload failed: {e}")
+            try:
+                self.agent.start()
+                import pwnagotchi
+                self.connection.set_device_name(pwnagotchi.name())
+            except Exception as e:
+                self.logger.debug(f"Agent/name restore after module reload failed: {e}")
+        finally:
+            with self._lock:
+                self._healing = False
 
         if recovered:
             with self._lock:
@@ -600,6 +614,11 @@ class BluetoothService:
     def bt_stuck(self):
         with self._lock:
             return self._bt_stuck
+
+    @property
+    def bt_healing(self):
+        with self._lock:
+            return self._healing
 
     def disconnect(self, mac):
         """Disconnect from a device."""

--- a/pwnagotchi/bluetooth/__init__.py
+++ b/pwnagotchi/bluetooth/__init__.py
@@ -37,8 +37,10 @@ class BluetoothService:
     STUCK_REBOOT_MIN_INTERVAL = 1800
     # Persisted last-reboot timestamp (survives the reboot to break loops)
     REBOOT_STAMP = "/root/.bt-tether-last-reboot"
-    # Don't reload the BT kernel module more than once per this window
-    BT_MODULE_RELOAD_MIN_INTERVAL = 300
+    # Don't reload the BT kernel module more than once per this window. Kept well
+    # below the reboot cadence: on combo chips the reload clears the wedge (a
+    # reboot often doesn't), so it should get first crack on every recurrence.
+    BT_MODULE_RELOAD_MIN_INTERVAL = 120
 
     def __init__(self, options=None, logger=None):
         self.options = options or {}
@@ -498,35 +500,46 @@ class BluetoothService:
         # Rung 2: module reload. Rate-limited so a persistent fault can't turn into
         # a reload loop.
         now = time.time()
-        if now - self._last_module_reload_time >= self.BT_MODULE_RELOAD_MIN_INTERVAL:
-            self._last_module_reload_time = now
+        if now - self._last_module_reload_time < self.BT_MODULE_RELOAD_MIN_INTERVAL:
+            # We reloaded very recently and it wedged again. A reboot doesn't clear
+            # this wedge on combo chips (the module reload does), so don't reboot on
+            # a fresh recurrence - flag it and let the next cycle retry the reload
+            # once the window opens, rather than reboot-looping.
             with self._lock:
-                self._message = "Bluetooth wedged - reloading module..."
-            # The reload restarts bluetooth, dropping the agent's bluetoothctl
-            # session - stop it first, bring it back after.
-            try:
-                self.agent.stop()
-            except Exception as e:
-                self.logger.debug(f"Agent stop during module reload failed: {e}")
+                self._bt_stuck = True
+                self._message = "Bluetooth wedged - will retry module reload"
+            self.logger.warning("Controller wedged again shortly after a module reload - waiting to retry (not rebooting)")
+            self._emit_event("bt:stuck", {})
+            return
 
-            recovered = self.connection.reload_bt_module()
+        self._last_module_reload_time = now
+        with self._lock:
+            self._message = "Bluetooth wedged - reloading module..."
+        # The reload restarts bluetooth, dropping the agent's bluetoothctl
+        # session - stop it first, bring it back after.
+        try:
+            self.agent.stop()
+        except Exception as e:
+            self.logger.debug(f"Agent stop during module reload failed: {e}")
 
-            try:
-                self.agent.start()
-                import pwnagotchi
-                self.connection.set_device_name(pwnagotchi.name())
-            except Exception as e:
-                self.logger.debug(f"Agent/name restore after module reload failed: {e}")
+        recovered = self.connection.reload_bt_module()
 
-            if recovered:
-                with self._lock:
-                    self._bt_stuck = False
-                    self._message = "Bluetooth recovered (module reload)"
-                self.logger.info("Controller recovered via module reload - link will re-establish")
-                self._emit_event("bt:recovered", {"method": "module_reload"})
-                return
+        try:
+            self.agent.start()
+            import pwnagotchi
+            self.connection.set_device_name(pwnagotchi.name())
+        except Exception as e:
+            self.logger.debug(f"Agent/name restore after module reload failed: {e}")
 
-        # Rung 3: module reload didn't help (or was rate-limited) - genuinely stuck.
+        if recovered:
+            with self._lock:
+                self._bt_stuck = False
+                self._message = "Bluetooth recovered (module reload)"
+            self.logger.info("Controller recovered via module reload - link will re-establish")
+            self._emit_event("bt:recovered", {"method": "module_reload"})
+            return
+
+        # Rung 3: the module reload actually RAN and FAILED - genuinely wedged.
         with self._lock:
             self._bt_stuck = True
             self._message = "Bluetooth stuck - power-cycle the Pi"

--- a/pwnagotchi/bluetooth/__init__.py
+++ b/pwnagotchi/bluetooth/__init__.py
@@ -56,8 +56,10 @@ class BluetoothService:
         # Let the monitor reconnect using the full connect flow (NAP + DHCP + verify)
         self.monitor.reconnect_callback = self.connect
         # Give the monitor the network layer so its half-open watchdog can probe
-        # whether the phone is actually reachable over the PAN.
+        # whether the phone is actually reachable over the PAN, and the recovery
+        # ladder so a watchdog heal shares the rate limit and agent handling.
         self.monitor.network = self.network
+        self.monitor.heal_callback = self._heal_bluetooth
         self.ui_renderer = UIRenderer()
 
         # State
@@ -456,9 +458,18 @@ class BluetoothService:
         thread.start()
         return True
 
-    def _recover_bluetooth(self):
-        """Clear a wedged controller (repeated br-connection-busy): restart the
-        Bluetooth stack and re-register the pairing agent.
+    def _heal_bluetooth(self, reason):
+        """Watchdog entry point into the recovery ladder: restart the stack and,
+        if that doesn't clear the wedge, escalate through the stuck path (module
+        reload -> opt-in reboot). Shares _recover_bluetooth's rate limit."""
+        outcome = self._recover_bluetooth(reason)
+        if outcome == "failed":
+            self._handle_bt_stuck()
+        return outcome
+
+    def _recover_bluetooth(self, reason="repeated br-connection-busy"):
+        """Clear a wedged controller: restart the Bluetooth stack and re-register
+        the pairing agent.
 
         Rate-limited so a persistent fault can't turn into a restart loop. Returns
         one of: "recovered" (restart completed, controller responsive),
@@ -470,7 +481,7 @@ class BluetoothService:
             return "rate_limited"
         self._last_recover_time = now
 
-        self.logger.warning("Repeated br-connection-busy - recovering the Bluetooth stack")
+        self.logger.warning(f"Recovering the Bluetooth stack ({reason})")
         try:
             self.agent.stop()
         except Exception as e:

--- a/pwnagotchi/bluetooth/__init__.py
+++ b/pwnagotchi/bluetooth/__init__.py
@@ -1,4 +1,8 @@
-"""Pwnagotchi Bluetooth service - core module for Bluetooth operations."""
+"""Pwnagotchi Bluetooth service - core module for Bluetooth operations.
+
+Ported from the bt-tether plugin by wsvdmeer
+(https://github.com/wsvdmeer/pwnagotchi-plugins/tree/main/bt-tether).
+"""
 
 import logging
 import threading

--- a/pwnagotchi/bluetooth/__init__.py
+++ b/pwnagotchi/bluetooth/__init__.py
@@ -37,6 +37,8 @@ class BluetoothService:
     STUCK_REBOOT_MIN_INTERVAL = 1800
     # Persisted last-reboot timestamp (survives the reboot to break loops)
     REBOOT_STAMP = "/root/.bt-tether-last-reboot"
+    # Don't reload the BT kernel module more than once per this window
+    BT_MODULE_RELOAD_MIN_INTERVAL = 300
 
     def __init__(self, options=None, logger=None):
         self.options = options or {}
@@ -63,6 +65,7 @@ class BluetoothService:
         self._initialized = False
         self._event_handlers = {}
         self._last_recover_time = 0
+        self._last_module_reload_time = 0
         # Wedged-controller ("stuck") tracking: set only when a bluetooth restart
         # did NOT clear the busy state (distinct from "phone tethering off").
         self._bt_stuck = False
@@ -486,14 +489,48 @@ class BluetoothService:
         return "recovered" if ok else "failed"
 
     def _handle_bt_stuck(self):
-        """A bluetooth restart did NOT clear the busy wedge - the controller is
-        genuinely stuck and only a power-cycle clears it. Flag it (surfaced on the
-        screen/web and in /status) and, if opted in, reboot.
+        """A bluetooth daemon restart did NOT clear the busy wedge. Escalate:
+        first try reloading the BT kernel module (re-downloads the firmware, which
+        clears wedges that survive both a restart AND a reboot); only if that fails
+        flag the controller stuck (surfaced on screen/web and in /status) and, if
+        opted in, reboot as the true last resort.
         """
+        # Rung 2: module reload. Rate-limited so a persistent fault can't turn into
+        # a reload loop.
+        now = time.time()
+        if now - self._last_module_reload_time >= self.BT_MODULE_RELOAD_MIN_INTERVAL:
+            self._last_module_reload_time = now
+            with self._lock:
+                self._message = "Bluetooth wedged - reloading module..."
+            # The reload restarts bluetooth, dropping the agent's bluetoothctl
+            # session - stop it first, bring it back after.
+            try:
+                self.agent.stop()
+            except Exception as e:
+                self.logger.debug(f"Agent stop during module reload failed: {e}")
+
+            recovered = self.connection.reload_bt_module()
+
+            try:
+                self.agent.start()
+                import pwnagotchi
+                self.connection.set_device_name(pwnagotchi.name())
+            except Exception as e:
+                self.logger.debug(f"Agent/name restore after module reload failed: {e}")
+
+            if recovered:
+                with self._lock:
+                    self._bt_stuck = False
+                    self._message = "Bluetooth recovered (module reload)"
+                self.logger.info("Controller recovered via module reload - link will re-establish")
+                self._emit_event("bt:recovered", {"method": "module_reload"})
+                return
+
+        # Rung 3: module reload didn't help (or was rate-limited) - genuinely stuck.
         with self._lock:
             self._bt_stuck = True
             self._message = "Bluetooth stuck - power-cycle the Pi"
-        self.logger.error("Bluetooth controller stuck after restart - a power-cycle is needed")
+        self.logger.error("Bluetooth controller stuck - module reload didn't clear it, a power-cycle is needed")
         self._emit_event("bt:stuck", {})
 
         if self.options.get("reboot_on_stuck_bluetooth", False):

--- a/pwnagotchi/bluetooth/__init__.py
+++ b/pwnagotchi/bluetooth/__init__.py
@@ -74,8 +74,8 @@ class BluetoothService:
         # did NOT clear the busy state (distinct from "phone tethering off").
         self._bt_stuck = False
         # True while the recovery ladder is actively resetting Bluetooth, so the
-        # display can say "Healing..." instead of a confusing Paired/Connected.
-        self._healing = False
+        # display can say "Recovering..." instead of a confusing Paired/Connected.
+        self._recovering = False
         self._connected_since_boot = False
 
         # Scan state tracking
@@ -486,7 +486,7 @@ class BluetoothService:
 
         self.logger.warning(f"Recovering the Bluetooth stack ({reason})")
         with self._lock:
-            self._healing = True
+            self._recovering = True
         try:
             try:
                 self.agent.stop()
@@ -508,7 +508,7 @@ class BluetoothService:
             return "recovered" if ok else "failed"
         finally:
             with self._lock:
-                self._healing = False
+                self._recovering = False
 
     def _handle_bt_stuck(self):
         """A bluetooth daemon restart did NOT clear the busy wedge. Escalate:
@@ -534,7 +534,7 @@ class BluetoothService:
 
         self._last_module_reload_time = now
         with self._lock:
-            self._healing = True
+            self._recovering = True
             self._message = "Bluetooth wedged - reloading module..."
         # The reload restarts bluetooth, dropping the agent's bluetoothctl
         # session - stop it first, bring it back after.
@@ -554,7 +554,7 @@ class BluetoothService:
                 self.logger.debug(f"Agent/name restore after module reload failed: {e}")
         finally:
             with self._lock:
-                self._healing = False
+                self._recovering = False
 
         if recovered:
             with self._lock:
@@ -616,9 +616,9 @@ class BluetoothService:
             return self._bt_stuck
 
     @property
-    def bt_healing(self):
+    def bt_recovering(self):
         with self._lock:
-            return self._healing
+            return self._recovering
 
     def disconnect(self, mac):
         """Disconnect from a device."""

--- a/pwnagotchi/bluetooth/__init__.py
+++ b/pwnagotchi/bluetooth/__init__.py
@@ -51,6 +51,9 @@ class BluetoothService:
         self.monitor = ConnectionMonitor(self.connection, logger=self.logger, options=self.options)
         # Let the monitor reconnect using the full connect flow (NAP + DHCP + verify)
         self.monitor.reconnect_callback = self.connect
+        # Give the monitor the network layer so its half-open watchdog can probe
+        # whether the phone is actually reachable over the PAN.
+        self.monitor.network = self.network
         self.ui_renderer = UIRenderer()
 
         # State

--- a/pwnagotchi/bluetooth/connection.py
+++ b/pwnagotchi/bluetooth/connection.py
@@ -129,7 +129,9 @@ class ConnectionManager:
                     ["systemctl", "restart", "bluetooth"],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
-                    timeout=self.SUBPROCESS_TIMEOUT_STANDARD,
+                    # A hung bluetoothd takes well over 5s to stop (see
+                    # force_restart_bluetooth) - same headroom here.
+                    timeout=self.BLUETOOTH_RESTART_CMD_TIMEOUT,
                 )
                 time.sleep(3)
                 return True
@@ -146,7 +148,7 @@ class ConnectionManager:
         'responsive' but stuck rejecting connects with br-connection-busy - the
         only thing that reliably clears that state.
         """
-        self.logger.warning("Restarting Bluetooth to clear a stuck (br-connection-busy) state")
+        self.logger.warning("Force-restarting Bluetooth to clear a wedged controller")
         try:
             subprocess.run(
                 ["systemctl", "restart", "bluetooth"],

--- a/pwnagotchi/bluetooth/connection.py
+++ b/pwnagotchi/bluetooth/connection.py
@@ -42,6 +42,10 @@ class ConnectionManager:
     # `systemctl restart bluetooth` on a wedged controller can take well over 5s
     # (bluetoothd hangs on stop until systemd's stop timeout), so give it room.
     BLUETOOTH_RESTART_CMD_TIMEOUT = 30
+    # Kernel transport module for the built-in Broadcom controller. Reloading it
+    # re-downloads the BT firmware, which clears a wedge that survives both a
+    # daemon restart and a full reboot. (Serial-attached combo chips: hci_uart.)
+    BT_MODULE = "hci_uart"
 
     def __init__(self, logger=None, options=None):
         self.logger = logger or logging.getLogger(__name__)
@@ -165,6 +169,54 @@ class ConnectionManager:
                 self.logger.info("Bluetooth restarted and responsive")
                 return True
         self.logger.warning("Bluetooth still not responsive after restart")
+        return False
+
+    def reload_bt_module(self):
+        """Reload the Bluetooth transport module to force a firmware re-download.
+
+        The rung between a daemon restart and a full reboot: on combo WiFi+BT
+        chips the controller firmware can wedge (HCI commands time out - the
+        kernel logs 'command tx timeout' / opcode failures with -110) in a way
+        that survives both 'systemctl restart bluetooth' AND a reboot, yet is
+        cleared by unloading and reloading the module. Runs as root (pwnagotchi
+        already runs as root, so no sudo); returns True if the controller comes
+        back responsive.
+        """
+        self.logger.warning(f"Reloading Bluetooth module ({self.BT_MODULE}) to reset a wedged controller")
+        try:
+            subprocess.run(
+                ["modprobe", "-r", self.BT_MODULE],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=self.BLUETOOTH_RESTART_CMD_TIMEOUT,
+            )
+            time.sleep(self.SUBPROCESS_TIMEOUT_MEDIUM)
+            subprocess.run(
+                ["modprobe", self.BT_MODULE],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=self.BLUETOOTH_RESTART_CMD_TIMEOUT,
+            )
+            time.sleep(self.SUBPROCESS_TIMEOUT_NORMAL)
+            subprocess.run(
+                ["systemctl", "restart", "bluetooth"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=self.BLUETOOTH_RESTART_CMD_TIMEOUT,
+            )
+        except Exception as e:
+            self.logger.warning(f"Bluetooth module reload failed: {e}")
+            return False
+
+        deadline = time.time() + self.BLUETOOTH_RESTART_TIMEOUT
+        while time.time() < deadline:
+            time.sleep(1)
+            if self.is_responsive():
+                self._run_cmd(["bluetoothctl", "power", "on"], capture=True, timeout=self.SUBPROCESS_TIMEOUT_NORMAL)
+                self._consecutive_busy = 0
+                self.logger.info("Bluetooth module reloaded and controller responsive")
+                return True
+        self.logger.warning("Bluetooth still not responsive after module reload")
         return False
 
     def get_status(self, mac):

--- a/pwnagotchi/bluetooth/monitor.py
+++ b/pwnagotchi/bluetooth/monitor.py
@@ -35,6 +35,11 @@ class ConnectionMonitor:
         # NetworkManager, set by BluetoothService; used by the half-open watchdog
         # to probe whether the phone is actually reachable over the PAN link.
         self.network = None
+        # Recovery entry point, set by BluetoothService. Routes a watchdog heal
+        # through the service's ladder (restart -> module reload -> opt-in reboot)
+        # with its shared rate limit and pairing-agent handling; falls back to a
+        # bare bluetooth restart if unset.
+        self.heal_callback = None
 
         self._current_mac = None
         self.last_known_connected = False
@@ -178,13 +183,15 @@ class ConnectionMonitor:
                     # Link reports connected - but on combo chips it can be
                     # half-open (bnep up, no traffic). Probe the phone and heal.
                     if status.get("pan_active"):
-                        self._check_half_open_link(mac)
+                        self._check_half_open_link()
                     else:
                         self._half_open_count = 0
                 else:
                     # Not connected: reconnect. Covers both a dropped link and an
                     # initial connect that hasn't succeeded yet (e.g. phone wasn't
-                    # in range at boot).
+                    # in range at boot). A stale half-open count must not carry
+                    # over into the next connection.
+                    self._half_open_count = 0
                     if self.last_known_connected:
                         self.logger.warning(f"Connection to {mac} dropped! Reconnecting...")
                     else:
@@ -239,7 +246,7 @@ class ConnectionMonitor:
             self._handle_reconnect_failure(mac)
             return False
 
-    def _check_half_open_link(self, mac):
+    def _check_half_open_link(self):
         """Detect a half-open PAN link (bnep up but phone unreachable) and, unless
         in dry-run, reset Bluetooth to recover. Called only while the link reports
         connected and a PAN interface is up. Honours the watchdog config."""
@@ -272,12 +279,16 @@ class ConnectionMonitor:
             )
             return
 
-        # Active heal: force a Bluetooth restart (the controller is responsive, so
-        # the normal busy self-heal never fires), then let the loop reconnect. On
-        # coexistence-wedged chips this escalates through the service's stuck path.
+        # Active heal: the controller is responsive (so the busy self-heal never
+        # fires) but the link is dead. Route through the service's recovery ladder
+        # (restart -> module reload -> opt-in reboot), which shares its rate limit
+        # and restores the pairing agent; then let the loop reconnect.
         self.logger.warning("Watchdog: resetting Bluetooth to clear the half-open link")
         try:
-            self.connection.force_restart_bluetooth()
+            if self.heal_callback:
+                self.heal_callback("half-open PAN link")
+            else:
+                self.connection.force_restart_bluetooth()
         except Exception as e:
             self.logger.error(f"Watchdog: Bluetooth reset failed: {e}")
         self.last_known_connected = False

--- a/pwnagotchi/bluetooth/monitor.py
+++ b/pwnagotchi/bluetooth/monitor.py
@@ -255,7 +255,21 @@ class ConnectionMonitor:
 
         reachable = self.network.pan_peer_reachable()
         if reachable is None:
-            return  # couldn't determine a peer to probe - don't act
+            # No peer to probe. That's expected briefly while DHCP runs, but a PAN
+            # that stays addressless is just as dead as a failed probe (over a
+            # half-open link the DHCP request itself gets no reply) - and with no
+            # address the monitor sees "connected" and would never intervene.
+            # Count it; the threshold gives DHCP minutes of grace to land.
+            iface = self.network.get_pan_interface()
+            if not iface:
+                return
+            ip = self.network.get_interface_ip(iface)
+            if (ip and not ip.startswith("169.254.")) or self.network.get_global_ipv6(iface):
+                # Link has an address, just no probeable peer - don't act (and a
+                # lease landing means any addressless streak is over).
+                self._half_open_count = 0
+                return
+            reachable = False
         if reachable:
             if self._half_open_count:
                 self.logger.debug("Watchdog: PAN link healthy again")

--- a/pwnagotchi/bluetooth/monitor.py
+++ b/pwnagotchi/bluetooth/monitor.py
@@ -75,6 +75,12 @@ class ConnectionMonitor:
             self.logger.error(f"Failed to start monitor: {e}")
             return False
 
+    @property
+    def link_stalled(self):
+        """True while the watchdog has unanswered peer probes on a live link -
+        the connection LOOKS up but may be half-open. Cleared by a healthy probe."""
+        return self._half_open_count > 0
+
     def set_device(self, mac):
         """Tell the monitor which device to watch for drops (called after a successful connect)."""
         with self._lock:

--- a/pwnagotchi/bluetooth/monitor.py
+++ b/pwnagotchi/bluetooth/monitor.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import logging
+from collections import deque
 from .connection import ConnectionManager
 from .device import BluetoothDevice
 
@@ -57,7 +58,11 @@ class ConnectionMonitor:
         self.watchdog_enabled = self.options.get("watchdog_enabled", True)
         self.watchdog_dry_run = self.options.get("watchdog_dry_run", True)
         self.watchdog_fail_threshold = self.options.get("watchdog_fail_threshold", 3)
-        self._half_open_count = 0
+        # Sliding window of recent probe results (True/False). Heal when at least
+        # watchdog_fail_threshold of the last (threshold+1) probes failed - fast on
+        # a dead link AND a flapping one, while a single stray ping loss can't trip
+        # it. Beats a running counter, which a flapping link dilutes indefinitely.
+        self._probe_history = deque(maxlen=self.watchdog_fail_threshold + 1)
 
     def start(self):
         """Start the monitoring thread."""
@@ -77,9 +82,10 @@ class ConnectionMonitor:
 
     @property
     def link_stalled(self):
-        """True while the watchdog has unanswered peer probes on a live link -
-        the connection LOOKS up but may be half-open. Cleared by a healthy probe."""
-        return self._half_open_count > 0
+        """True when the most recent peer probe failed on a live link - the
+        connection LOOKS up but may be half-open. Reflects the latest probe so it
+        clears as soon as one succeeds, rather than lingering for the whole window."""
+        return bool(self._probe_history) and self._probe_history[-1] is False
 
     def set_device(self, mac):
         """Tell the monitor which device to watch for drops (called after a successful connect)."""
@@ -191,13 +197,13 @@ class ConnectionMonitor:
                     if status.get("pan_active"):
                         self._check_half_open_link()
                     else:
-                        self._half_open_count = 0
+                        self._probe_history.clear()
                 else:
                     # Not connected: reconnect. Covers both a dropped link and an
                     # initial connect that hasn't succeeded yet (e.g. phone wasn't
-                    # in range at boot). A stale half-open count must not carry
+                    # in range at boot). A stale probe history must not carry
                     # over into the next connection.
-                    self._half_open_count = 0
+                    self._probe_history.clear()
                     if self.last_known_connected:
                         self.logger.warning(f"Connection to {mac} dropped! Reconnecting...")
                     else:
@@ -272,32 +278,28 @@ class ConnectionMonitor:
             ip = self.network.get_interface_ip(iface)
             if (ip and not ip.startswith("169.254.")) or self.network.get_global_ipv6(iface):
                 # Link has an address, just no probeable peer - don't act (and a
-                # lease landing means any addressless streak is over).
-                self._half_open_count = 0
+                # lease landing clears any recent failures).
+                self._probe_history.clear()
                 return
             reachable = False
-        if reachable:
-            # Decay rather than hard-reset: a flapping link (bad,bad,good,bad,bad)
-            # would otherwise reset on every stray good probe and never reach the
-            # threshold to heal. Decrementing lets a persistently-bad-but-flapping
-            # link still climb, while a genuinely healthy link (all good) decays to
-            # 0 and stays there.
-            if self._half_open_count:
-                self._half_open_count -= 1
-                if self._half_open_count == 0:
-                    self.logger.debug("Watchdog: PAN link healthy again")
-            return
 
-        # bnep up but phone unreachable -> half-open
-        self._half_open_count += 1
+        # Record this probe in the sliding window and heal when too many of the
+        # recent probes failed. Unlike a running counter, a window can't be diluted
+        # forever by a flapping link, and one stray good/bad read never dominates.
+        self._probe_history.append(bool(reachable))
+        fails = sum(1 for r in self._probe_history if r is False)
+        if reachable:
+            if fails == 0:
+                pass  # fully healthy window - nothing to log
+            return
         self.logger.warning(
             f"Watchdog: PAN link looks half-open (bnep up, phone unreachable) "
-            f"[{self._half_open_count}/{self.watchdog_fail_threshold}]"
+            f"[{fails}/{self.watchdog_fail_threshold} in last {len(self._probe_history)}]"
         )
-        if self._half_open_count < self.watchdog_fail_threshold:
+        if fails < self.watchdog_fail_threshold:
             return
 
-        self._half_open_count = 0
+        self._probe_history.clear()
         if self.watchdog_dry_run:
             self.logger.warning(
                 "Watchdog: DRY-RUN - would reset Bluetooth now to clear the "

--- a/pwnagotchi/bluetooth/monitor.py
+++ b/pwnagotchi/bluetooth/monitor.py
@@ -277,9 +277,15 @@ class ConnectionMonitor:
                 return
             reachable = False
         if reachable:
+            # Decay rather than hard-reset: a flapping link (bad,bad,good,bad,bad)
+            # would otherwise reset on every stray good probe and never reach the
+            # threshold to heal. Decrementing lets a persistently-bad-but-flapping
+            # link still climb, while a genuinely healthy link (all good) decays to
+            # 0 and stays there.
             if self._half_open_count:
-                self.logger.debug("Watchdog: PAN link healthy again")
-            self._half_open_count = 0
+                self._half_open_count -= 1
+                if self._half_open_count == 0:
+                    self.logger.debug("Watchdog: PAN link healthy again")
             return
 
         # bnep up but phone unreachable -> half-open

--- a/pwnagotchi/bluetooth/monitor.py
+++ b/pwnagotchi/bluetooth/monitor.py
@@ -295,7 +295,7 @@ class ConnectionMonitor:
         if self.watchdog_dry_run:
             self.logger.warning(
                 "Watchdog: DRY-RUN - would reset Bluetooth now to clear the "
-                "half-open link (set watchdog_dry_run = false to enable healing)"
+                "half-open link (set watchdog_dry_run = false to enable recovery)"
             )
             return
 

--- a/pwnagotchi/bluetooth/monitor.py
+++ b/pwnagotchi/bluetooth/monitor.py
@@ -32,6 +32,9 @@ class ConnectionMonitor:
         # to its connect(); falls back to a NAP-only reconnect if unset.
         self.reconnect_callback = None
         self.RECONNECT_VERIFY_TIMEOUT = 30
+        # NetworkManager, set by BluetoothService; used by the half-open watchdog
+        # to probe whether the phone is actually reachable over the PAN link.
+        self.network = None
 
         self._current_mac = None
         self.last_known_connected = False
@@ -42,6 +45,14 @@ class ConnectionMonitor:
         self.reconnect_interval = self.options.get("reconnect_interval", self.DEFAULT_RECONNECT_INTERVAL)
         self.reconnect_fast_interval = self.options.get("reconnect_fast_interval", self.DEFAULT_RECONNECT_FAST_INTERVAL)
         self._disconnected_cycles = 0
+
+        # Half-open PAN watchdog: the link can report "connected" while no traffic
+        # actually passes (combo-chip coexistence). Detect it by probing the phone
+        # over the PAN and, unless dry-run, reset Bluetooth to recover.
+        self.watchdog_enabled = self.options.get("watchdog_enabled", True)
+        self.watchdog_dry_run = self.options.get("watchdog_dry_run", True)
+        self.watchdog_fail_threshold = self.options.get("watchdog_fail_threshold", 3)
+        self._half_open_count = 0
 
     def start(self):
         """Start the monitoring thread."""
@@ -164,6 +175,12 @@ class ConnectionMonitor:
                     self.last_known_connected = True
                     self.reconnect_failure_count = 0
                     self.first_failure_time = None
+                    # Link reports connected - but on combo chips it can be
+                    # half-open (bnep up, no traffic). Probe the phone and heal.
+                    if status.get("pan_active"):
+                        self._check_half_open_link(mac)
+                    else:
+                        self._half_open_count = 0
                 else:
                     # Not connected: reconnect. Covers both a dropped link and an
                     # initial connect that hasn't succeeded yet (e.g. phone wasn't
@@ -221,6 +238,49 @@ class ConnectionMonitor:
             self.logger.error(f"Reconnect failed: {e}")
             self._handle_reconnect_failure(mac)
             return False
+
+    def _check_half_open_link(self, mac):
+        """Detect a half-open PAN link (bnep up but phone unreachable) and, unless
+        in dry-run, reset Bluetooth to recover. Called only while the link reports
+        connected and a PAN interface is up. Honours the watchdog config."""
+        if not self.watchdog_enabled or self.network is None:
+            return
+
+        reachable = self.network.pan_peer_reachable()
+        if reachable is None:
+            return  # couldn't determine a peer to probe - don't act
+        if reachable:
+            if self._half_open_count:
+                self.logger.debug("Watchdog: PAN link healthy again")
+            self._half_open_count = 0
+            return
+
+        # bnep up but phone unreachable -> half-open
+        self._half_open_count += 1
+        self.logger.warning(
+            f"Watchdog: PAN link looks half-open (bnep up, phone unreachable) "
+            f"[{self._half_open_count}/{self.watchdog_fail_threshold}]"
+        )
+        if self._half_open_count < self.watchdog_fail_threshold:
+            return
+
+        self._half_open_count = 0
+        if self.watchdog_dry_run:
+            self.logger.warning(
+                "Watchdog: DRY-RUN - would reset Bluetooth now to clear the "
+                "half-open link (set watchdog_dry_run = false to enable healing)"
+            )
+            return
+
+        # Active heal: force a Bluetooth restart (the controller is responsive, so
+        # the normal busy self-heal never fires), then let the loop reconnect. On
+        # coexistence-wedged chips this escalates through the service's stuck path.
+        self.logger.warning("Watchdog: resetting Bluetooth to clear the half-open link")
+        try:
+            self.connection.force_restart_bluetooth()
+        except Exception as e:
+            self.logger.error(f"Watchdog: Bluetooth reset failed: {e}")
+        self.last_known_connected = False
 
     def _handle_reconnect_failure(self, mac):
         """Handle a reconnection failure."""

--- a/pwnagotchi/bluetooth/network.py
+++ b/pwnagotchi/bluetooth/network.py
@@ -565,6 +565,75 @@ class NetworkManager:
             self.logger.error(f"Failed to get PAN interface: {e}")
             return None
 
+    def get_pan_peer_ip(self, iface):
+        """Best-effort phone IP on the PAN link, for reachability probing.
+
+        Tries: default route via the iface -> existing neighbour -> our subnet .1.
+        """
+        try:
+            out = subprocess.run(
+                ["ip", "route", "show", "default", "dev", iface],
+                capture_output=True, text=True, timeout=self.SUBPROCESS_TIMEOUT_NORMAL,
+            ).stdout
+            m = re.search(r"default via (\d+\.\d+\.\d+\.\d+)", out)
+            if m:
+                return m.group(1)
+
+            out = subprocess.run(
+                ["ip", "neigh", "show", "dev", iface],
+                capture_output=True, text=True, timeout=self.SUBPROCESS_TIMEOUT_NORMAL,
+            ).stdout
+            m = re.search(r"^(\d+\.\d+\.\d+\.\d+)", out.strip())
+            if m:
+                return m.group(1)
+
+            out = subprocess.run(
+                ["ip", "-4", "addr", "show", "dev", iface],
+                capture_output=True, text=True, timeout=self.SUBPROCESS_TIMEOUT_NORMAL,
+            ).stdout
+            m = re.search(r"inet (\d+\.\d+\.\d+)\.\d+", out)
+            if m:
+                return m.group(1) + ".1"
+        except Exception as e:
+            self.logger.debug(f"Peer IP probe failed: {e}")
+        return None
+
+    def pan_peer_reachable(self):
+        """Probe whether the phone is actually reachable over the PAN link.
+
+        Returns True (reachable), False (half-open / unreachable), or None (unknown
+        - no interface or no peer to probe, so the caller should not act).
+        """
+        iface = self.get_pan_interface()
+        if not iface:
+            return None
+        peer = self.get_pan_peer_ip(iface)
+        if not peer:
+            return None
+        try:
+            r = subprocess.run(
+                ["ping", "-c", "1", "-W", "2", "-I", iface, peer],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                timeout=self.SUBPROCESS_TIMEOUT_STANDARD,
+            )
+            if r.returncode == 0:
+                return True
+        except Exception:
+            pass
+        # Ping failed (or was filtered) - confirm via the neighbour state. A
+        # REACHABLE/STALE/DELAY/PROBE entry means L2 is fine and ping is just
+        # blocked; INCOMPLETE/FAILED/absent means the link is genuinely half-open.
+        try:
+            out = subprocess.run(
+                ["ip", "neigh", "show", "to", peer, "dev", iface],
+                capture_output=True, text=True, timeout=self.SUBPROCESS_TIMEOUT_NORMAL,
+            ).stdout
+            if any(s in out for s in ("REACHABLE", "STALE", "DELAY", "PROBE")):
+                return True
+        except Exception:
+            pass
+        return False
+
     def get_interface_ip(self, iface):
         """Get IP address of a network interface"""
         try:

--- a/pwnagotchi/bluetooth/network.py
+++ b/pwnagotchi/bluetooth/network.py
@@ -620,15 +620,18 @@ class NetworkManager:
                 return True
         except Exception:
             pass
-        # Ping failed (or was filtered) - confirm via the neighbour state. A
-        # REACHABLE/STALE/DELAY/PROBE entry means L2 is fine and ping is just
-        # blocked; INCOMPLETE/FAILED/absent means the link is genuinely half-open.
+        # Ping failed (or was filtered) - confirm via the neighbour state, but only
+        # trust an ACTIVELY-confirmed entry (REACHABLE/DELAY/PROBE) as "ping merely
+        # blocked." Deliberately exclude STALE: the kernel keeps the last-known MAC
+        # in STALE for minutes after a link goes dead, so treating STALE as reachable
+        # produces false-"healthy" reads on a half-open link (and masks it from the
+        # watchdog). No active entry -> treat as unreachable.
         try:
             out = subprocess.run(
                 ["ip", "neigh", "show", "to", peer, "dev", iface],
                 capture_output=True, text=True, timeout=self.SUBPROCESS_TIMEOUT_NORMAL,
             ).stdout
-            if any(s in out for s in ("REACHABLE", "STALE", "DELAY", "PROBE")):
+            if any(s in out for s in ("REACHABLE", "DELAY", "PROBE")):
                 return True
         except Exception:
             pass

--- a/pwnagotchi/bluetooth/ui.py
+++ b/pwnagotchi/bluetooth/ui.py
@@ -16,6 +16,8 @@ class UIRenderer:
         ">": "Connecting",
         "R": "Reconnecting",
         "D": "Disconnecting",
+        "H": "Healing Bluetooth",
+        "~": "Link stalled (probing)",
         "!": "Controller stuck - power-cycle",
         "?": "Error",
     }
@@ -23,6 +25,12 @@ class UIRenderer:
     # Shown when a bluetooth restart could not clear a wedged controller
     STUCK_ICON = "!"
     STUCK_TEXT = "BT:Stuck-reboot"
+    # Shown while the recovery ladder is actively resetting Bluetooth
+    HEALING_ICON = "H"
+    HEALING_TEXT = "BT:Healing..."
+    # Shown while the watchdog is counting failed peer probes on a live link
+    STALLED_ICON = "~"
+    STALLED_TEXT = "BT:Stalled?"
 
     @staticmethod
     def strip_ansi(text):
@@ -33,13 +41,19 @@ class UIRenderer:
         return ansi_escape.sub("", text)
 
     @classmethod
-    def format_status(cls, status_dict, bt_stuck=False):
+    def format_status(cls, status_dict, bt_stuck=False, healing=False, stalled=False):
         """Format status dict into the detailed display line.
 
         Shows the tether address once PAN is up (IPv4, falling back to IPv6 for
-        v6-only tethering). bt_stuck takes precedence while not connected: a
-        bluetooth restart could not clear the controller, so a power-cycle is
-        needed and the user should see that rather than a plain "Paired".
+        v6-only tethering). Transient truths outrank the steady-state view:
+        - bt_stuck (while not connected): a bluetooth restart could not clear the
+          controller, so a power-cycle is needed - not a plain "Paired".
+        - healing: the recovery ladder is actively resetting Bluetooth - the link
+          bouncing through Paired/Connected is expected, not a problem.
+        - stalled: the watchdog is counting failed peer probes - the link LOOKS
+          connected but may be half-open, so don't show a healthy IP.
+        A PAN without an address is shown as "No IP" (DHCP starving), which is a
+        different situation than a healthy connect.
         """
         connected = status_dict.get("connected", False)
         paired = status_dict.get("paired", False)
@@ -49,9 +63,13 @@ class UIRenderer:
 
         if bt_stuck and not connected:
             return cls.STUCK_TEXT
+        if healing:
+            return cls.HEALING_TEXT
 
         if pan_active:
-            return f"BT:{ip_address}" if ip_address else "BT:Connected"
+            if stalled:
+                return cls.STALLED_TEXT
+            return f"BT:{ip_address}" if ip_address else "BT:No IP"
         elif connected and trusted:
             return "BT:Trusted"
         elif connected:
@@ -62,10 +80,11 @@ class UIRenderer:
             return "BT:- -"
 
     @classmethod
-    def get_status_icon(cls, status_dict, bt_stuck=False):
+    def get_status_icon(cls, status_dict, bt_stuck=False, healing=False, stalled=False):
         """Get the single-character status icon.
 
-        Settled states are uppercase (C/T/N/P/X); "!" flags a wedged controller.
+        Settled states are uppercase (C/T/N/P/X); "H" is a heal in progress,
+        "~" a suspect (possibly half-open) link, "!" a wedged controller.
         """
         pan_active = status_dict.get("pan_active", False)
         connected = status_dict.get("connected", False)
@@ -74,9 +93,11 @@ class UIRenderer:
 
         if bt_stuck and not connected:
             return cls.STUCK_ICON
+        if healing:
+            return cls.HEALING_ICON
 
         if pan_active:
-            return "C"
+            return cls.STALLED_ICON if stalled else "C"
         elif connected and trusted:
             return "T"
         elif connected:

--- a/pwnagotchi/bluetooth/ui.py
+++ b/pwnagotchi/bluetooth/ui.py
@@ -14,9 +14,8 @@ class UIRenderer:
         "I": "Initializing",
         "S": "Scanning",
         ">": "Connecting",
-        "R": "Reconnecting",
+        "R": "Recovering Bluetooth",
         "D": "Disconnecting",
-        "H": "Healing Bluetooth",
         "~": "Link stalled (probing)",
         "!": "Controller stuck - power-cycle",
         "?": "Error",
@@ -26,8 +25,8 @@ class UIRenderer:
     STUCK_ICON = "!"
     STUCK_TEXT = "BT:Stuck-reboot"
     # Shown while the recovery ladder is actively resetting Bluetooth
-    HEALING_ICON = "H"
-    HEALING_TEXT = "BT:Healing..."
+    RECOVERING_ICON = "R"
+    RECOVERING_TEXT = "BT:Recovering..."
     # Shown while the watchdog is counting failed peer probes on a live link
     STALLED_ICON = "~"
     STALLED_TEXT = "BT:Stalled?"
@@ -41,14 +40,14 @@ class UIRenderer:
         return ansi_escape.sub("", text)
 
     @classmethod
-    def format_status(cls, status_dict, bt_stuck=False, healing=False, stalled=False):
+    def format_status(cls, status_dict, bt_stuck=False, recovering=False, stalled=False):
         """Format status dict into the detailed display line.
 
         Shows the tether address once PAN is up (IPv4, falling back to IPv6 for
         v6-only tethering). Transient truths outrank the steady-state view:
         - bt_stuck (while not connected): a bluetooth restart could not clear the
           controller, so a power-cycle is needed - not a plain "Paired".
-        - healing: the recovery ladder is actively resetting Bluetooth - the link
+        - recovering: the recovery ladder is actively resetting Bluetooth - the link
           bouncing through Paired/Connected is expected, not a problem.
         - stalled: the watchdog is counting failed peer probes - the link LOOKS
           connected but may be half-open, so don't show a healthy IP.
@@ -63,8 +62,8 @@ class UIRenderer:
 
         if bt_stuck and not connected:
             return cls.STUCK_TEXT
-        if healing:
-            return cls.HEALING_TEXT
+        if recovering:
+            return cls.RECOVERING_TEXT
 
         if pan_active:
             if stalled:
@@ -80,10 +79,10 @@ class UIRenderer:
             return "BT:- -"
 
     @classmethod
-    def get_status_icon(cls, status_dict, bt_stuck=False, healing=False, stalled=False):
+    def get_status_icon(cls, status_dict, bt_stuck=False, recovering=False, stalled=False):
         """Get the single-character status icon.
 
-        Settled states are uppercase (C/T/N/P/X); "H" is a heal in progress,
+        Settled states are uppercase (C/T/N/P/X); "R" is a recovery in progress,
         "~" a suspect (possibly half-open) link, "!" a wedged controller.
         """
         pan_active = status_dict.get("pan_active", False)
@@ -93,8 +92,8 @@ class UIRenderer:
 
         if bt_stuck and not connected:
             return cls.STUCK_ICON
-        if healing:
-            return cls.HEALING_ICON
+        if recovering:
+            return cls.RECOVERING_ICON
 
         if pan_active:
             return cls.STALLED_ICON if stalled else "C"

--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -50,6 +50,9 @@ reconnect_failure_cooldown = 300         # Pause auto-reconnect this long after 
 nap_connect_timeout = 20                 # Wall-clock cap on a single NAP connect attempt
 fast_dhcp = true                         # Skip pointless ARP probe/backoff on the point-to-point PAN link
 reboot_on_stuck_bluetooth = false        # If a BT restart can't clear a wedged controller, reboot the Pi (opt-in)
+watchdog_enabled = true                  # Detect a half-open PAN link (bnep up but phone unreachable)
+watchdog_dry_run = true                  # Only log half-open detections; set false to auto-reset Bluetooth
+watchdog_fail_threshold = 3              # Consecutive unreachable probes before the watchdog acts
 
 [main.plugins.fix_services]
 enabled = true

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -28,7 +28,7 @@ from flask import render_template_string, request, jsonify
 
 class BtTether(Plugin):
     __author__ = "wsvdmeer"
-    __version__ = "2.1.0"
+    __version__ = "2.2.0"
     __license__ = "GPL3"
     __description__ = "Guided Bluetooth tethering"
 

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -377,14 +377,19 @@ class BtTether(Plugin):
                     current_mac = device.mac
                     break
 
+        # Report the CORE service state (CONNECTING/PAIRING/TRUSTING/...), not the
+        # plugin's IDLE/CONNECTED/ERROR shadow - the web UI gates its live refresh
+        # on this to show in-progress pair/connect operations.
+        core_status = self.bt.status
+        in_progress = core_status in ("PAIRING", "TRUSTING", "CONNECTING", "RECONNECTING")
         return jsonify({
-            "status": self._status,
+            "status": core_status,
             "message": self._message,
             "mac": current_mac,
             "initialized": self.bt.initialized,
-            "scanning": False,
-            "connection_in_progress": False,
-            "disconnecting": False,
+            "scanning": core_status == "SCANNING",
+            "connection_in_progress": in_progress,
+            "disconnecting": core_status == "DISCONNECTING",
             "untrusting": False,
             "initializing": not self.bt.initialized,
             "bt_stuck": self.bt.bt_stuck,
@@ -884,9 +889,12 @@ class BtTether(Plugin):
         try {
           await fetch('/plugins/bt-tether/scan', { method: 'GET' });
 
-          // Poll /scan-progress every 1 second to show devices as they appear
+          // Poll /scan-progress every 1 second to show devices as they appear.
+          // maxPolls must exceed the backend scan duration (30s) so we actually
+          // observe scanning flip to false and reach the clean completion branch;
+          // otherwise the "still scanning" spinner is left on screen forever.
           let pollCount = 0;
-          const maxPolls = 30;
+          const maxPolls = 40;
           let lastDeviceCount = 0;
           let scanProgressInterval = setInterval(async () => {
             pollCount++;
@@ -934,7 +942,11 @@ class BtTether(Plugin):
 
               if (pollCount >= maxPolls) {
                 clearInterval(scanProgressInterval);
-                if (lastDeviceCount === 0) {
+                // Always finalize the status line (clears the spinner), whether or
+                // not devices were found - never leave "...still scanning" up.
+                if (lastDeviceCount > 0) {
+                  scanStatus.textContent = `Scan complete - Found ${lastDeviceCount} device(s):`;
+                } else {
                   scanStatus.textContent = 'Scan timeout - No devices found';
                 }
                 scanBtn.disabled = false;
@@ -953,8 +965,23 @@ class BtTether(Plugin):
       }
 
       async function pairAndConnectDevice(mac, name) {
-        await fetch(`/plugins/bt-tether/pair-device?mac=${encodeURIComponent(mac)}&name=${encodeURIComponent(name)}`);
         macInput.value = mac;
+        // Immediate feedback + clear the scan list so the just-paired device
+        // stops showing a "Pair" button while the async connect runs.
+        const scanStatus = document.getElementById('scanStatus');
+        const deviceList = document.getElementById('deviceList');
+        const scanResults = document.getElementById('scanResults');
+        if (scanStatus) scanStatus.innerHTML = `<span class="spinner"></span> Pairing with ${name}...`;
+        if (deviceList) deviceList.innerHTML = '';
+        try {
+          await fetch(`/plugins/bt-tether/pair-device?mac=${encodeURIComponent(mac)}&name=${encodeURIComponent(name)}`);
+        } catch (e) {
+          console.error('Pair failed:', e);
+        }
+        // Hide the scan panel and refresh the device summary + live status. Status
+        // polling now works because /status reports the core CONNECTING state.
+        if (scanResults) scanResults.style.display = 'none';
+        loadTrustedDevicesSummary();
         setTimeout(checkConnectionStatus, 1000);
       }
 

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -205,19 +205,19 @@ class BtTether(Plugin):
 
             # Rendering (glyph + detailed line) lives in the core UIRenderer so the
             # logic is shared and testable. Transient flags: bt_stuck is a wedged
-            # controller needing a power-cycle, bt_healing an active recovery
+            # controller needing a power-cycle, bt_recovering an active recovery
             # (restart/module reload) and link_stalled a suspect half-open link -
             # each shown instead of a misleading Paired/Connected/IP.
             bt_stuck = self.bt.bt_stuck
-            healing = self.bt.bt_healing
+            recovering = self.bt.bt_recovering
             stalled = self.bt.monitor.link_stalled
             renderer = self.bt.ui_renderer
-            detailed = renderer.format_status(cached_status, bt_stuck=bt_stuck, healing=healing, stalled=stalled)
+            detailed = renderer.format_status(cached_status, bt_stuck=bt_stuck, recovering=recovering, stalled=stalled)
             # Keep the bare text for /status (the "BT:" prefix is display-only)
             self._message = detailed[3:] if detailed.startswith("BT:") else detailed
 
             if self.show_mini_status:
-                ui.set("bt-status", renderer.get_status_icon(cached_status, bt_stuck=bt_stuck, healing=healing, stalled=stalled))
+                ui.set("bt-status", renderer.get_status_icon(cached_status, bt_stuck=bt_stuck, recovering=recovering, stalled=stalled))
 
             if self.show_detailed_status:
                 ui.set("bt-detail", detailed)

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -393,6 +393,7 @@ class BtTether(Plugin):
             "untrusting": False,
             "initializing": not self.bt.initialized,
             "bt_stuck": self.bt.bt_stuck,
+            "bt_recovering": self.bt.bt_recovering,
         })
 
     def _get_connection_status(self, mac):
@@ -603,6 +604,8 @@ class BtTether(Plugin):
         <div id="trustedDevicesSummary" style="color: #4ec9b0; font-size: 14px;">Loading...</div>
       </div>
 
+      <div id="statusBanner" style="display: none; padding: 10px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 13px; font-weight: bold;"></div>
+
       <div style="background: #0d1117; color: #d4d4d4; padding: 12px; border-radius: 4px; margin-bottom: 12px; font-family: 'Courier New', monospace; font-size: 12px; line-height: 1.5;">
         <div style="color: #888; margin-bottom: 8px;">Connection Status:</div>
         <div id="statusPaired" style="margin: 4px 0;">📱 Paired: <span>Checking...</span></div>
@@ -662,6 +665,14 @@ class BtTether(Plugin):
       const macInput = document.getElementById("macInput");
       let statusInterval = null;
       let logInterval = null;
+
+      // Bluetooth device names are attacker-controllable - escape before inserting
+      // into innerHTML so a crafted name can't inject markup/script.
+      function escapeHtml(s) {
+        return String(s == null ? '' : s)
+          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+      }
 
       // Show initializing state first
       setInitializingStatus();
@@ -770,8 +781,30 @@ class BtTether(Plugin):
             `🔐 Trusted: <span style="color: ${trusted ? '#4ec9b0' : '#f48771'};">${trusted ? '✓ Yes' : '✗ No'}</span>`;
           document.getElementById("statusConnected").innerHTML =
             `🔵 Connected: <span style="color: ${connected ? '#4ec9b0' : '#f48771'};">${connected ? '✓ Yes' : '✗ No'}</span>`;
+          // A PAN that's up but has no IP is half-open, not "Active" - show No IP.
+          const online = pan_active && !!ip_address;
+          const netLabel = online ? '✓ Active' : (pan_active ? '⚠ No IP' : '✗ Not Active');
+          const netColor = online ? '#4ec9b0' : (pan_active ? '#d29922' : '#f48771');
           document.getElementById("statusInternet").innerHTML =
-            `🌐 Internet: <span style="color: ${pan_active ? '#4ec9b0' : '#f48771'};">${pan_active ? '✓ Active' : '✗ Not Active'}</span>${data.interface ? ` <span style="color: #888;">(${data.interface})</span>` : ''}`;
+            `🌐 Internet: <span style="color: ${netColor};">${netLabel}</span>${data.interface ? ` <span style="color: #888;">(${escapeHtml(data.interface)})</span>` : ''}`;
+
+          // Trouble banner: surface stuck/recovering/stalled/messages the boolean
+          // rows can't convey, so the page explains what's happening.
+          const banner = document.getElementById('statusBanner');
+          if (banner) {
+            let text = '', bg = '';
+            if (statusData.bt_stuck) {
+              text = '⛔ Bluetooth controller stuck — a power-cycle may be needed'; bg = '#5a1e1e';
+            } else if (statusData.bt_recovering) {
+              text = '🔧 Recovering Bluetooth…'; bg = '#5a4a1e';
+            } else if (pan_active && !ip_address) {
+              text = '⚠ Link up but no IP (DHCP not completed / half-open)'; bg = '#5a4a1e';
+            } else if (statusData.message && /stall|half-open|recover|wedge|stuck/i.test(statusData.message)) {
+              text = '⚠ ' + escapeHtml(statusData.message); bg = '#5a4a1e';
+            }
+            if (text) { banner.style.display = 'block'; banner.style.background = bg; banner.style.color = '#fff'; banner.innerHTML = text; }
+            else { banner.style.display = 'none'; }
+          }
 
           const statusIPElement = document.getElementById('statusIP');
           if (ip_address && pan_active) {
@@ -913,12 +946,17 @@ class BtTether(Plugin):
                   progressData.devices.forEach(device => {
                     const div = document.createElement('div');
                     div.className = 'device-item';
+                    // encodeURIComponent yields only URL-safe chars (no quotes,
+                    // backslashes, or <>), so it's safe both inside the onclick
+                    // single-quotes and in HTML; the handler decodes it back.
+                    const encName = encodeURIComponent(device.name || '');
+                    const encMac = encodeURIComponent(device.mac || '');
                     div.innerHTML = `
                       <div style="flex: 1; font-family: 'Courier New', monospace; font-size: 12px;">
-                        <b>${device.name}</b><br>
-                        <small style="color: #888;">${device.mac}</small>
+                        <b>${escapeHtml(device.name)}</b><br>
+                        <small style="color: #888;">${escapeHtml(device.mac)}</small>
                       </div>
-                      <button onclick="pairAndConnectDevice('${device.mac}', '${device.name.replace(/'/g, "\\'")}'); return false;" class="success" style="margin: 0; padding: 6px 12px; font-size: 12px;">Pair</button>
+                      <button onclick="pairAndConnectDevice(decodeURIComponent('${encMac}'), decodeURIComponent('${encName}')); return false;" class="success" style="margin: 0; padding: 6px 12px; font-size: 12px;">Pair</button>
                     `;
                     deviceList.appendChild(div);
                   });
@@ -971,7 +1009,7 @@ class BtTether(Plugin):
         const scanStatus = document.getElementById('scanStatus');
         const deviceList = document.getElementById('deviceList');
         const scanResults = document.getElementById('scanResults');
-        if (scanStatus) scanStatus.innerHTML = `<span class="spinner"></span> Pairing with ${name}...`;
+        if (scanStatus) scanStatus.innerHTML = `<span class="spinner"></span> Pairing with ${escapeHtml(name)}...`;
         if (deviceList) deviceList.innerHTML = '';
         try {
           await fetch(`/plugins/bt-tether/pair-device?mac=${encodeURIComponent(mac)}&name=${encodeURIComponent(name)}`);
@@ -999,12 +1037,12 @@ class BtTether(Plugin):
             // Hide device discovery section only if a device is actively connected
             if (connectedDevice) {
               deviceDiscoverySection.style.display = 'none';
-              summaryDiv.innerHTML = `<span style="color: #3fb950;">🔵 Connected to ${connectedDevice.name}</span><br><small style="color: #888;">${connectedDevice.mac}</small>`;
+              summaryDiv.innerHTML = `<span style="color: #3fb950;">🔵 Connected to ${escapeHtml(connectedDevice.name)}</span><br><small style="color: #888;">${escapeHtml(connectedDevice.mac)}</small>`;
             } else if (napDevices.length > 0) {
               // Show device list and discovery section if not connected
               deviceDiscoverySection.style.display = 'block';
               summaryDiv.innerHTML = napDevices.map(d =>
-                `<div style="margin: 4px 0;">📱 ${d.name}<br><small style="color: #888;">${d.mac}</small></div>`
+                `<div style="margin: 4px 0;">📱 ${escapeHtml(d.name)}<br><small style="color: #888;">${escapeHtml(d.mac)}</small></div>`
               ).join('');
             } else {
               // No tethering support

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -204,17 +204,20 @@ class BtTether(Plugin):
                 self._phone_name = connected_device.name
 
             # Rendering (glyph + detailed line) lives in the core UIRenderer so the
-            # logic is shared and testable. bt_stuck flags a wedged controller that a
-            # bluetooth restart could not clear, i.e. a power-cycle is needed; the
-            # renderer only surfaces it while not connected.
+            # logic is shared and testable. Transient flags: bt_stuck is a wedged
+            # controller needing a power-cycle, bt_healing an active recovery
+            # (restart/module reload) and link_stalled a suspect half-open link -
+            # each shown instead of a misleading Paired/Connected/IP.
             bt_stuck = self.bt.bt_stuck
+            healing = self.bt.bt_healing
+            stalled = self.bt.monitor.link_stalled
             renderer = self.bt.ui_renderer
-            detailed = renderer.format_status(cached_status, bt_stuck=bt_stuck)
+            detailed = renderer.format_status(cached_status, bt_stuck=bt_stuck, healing=healing, stalled=stalled)
             # Keep the bare text for /status (the "BT:" prefix is display-only)
             self._message = detailed[3:] if detailed.startswith("BT:") else detailed
 
             if self.show_mini_status:
-                ui.set("bt-status", renderer.get_status_icon(cached_status, bt_stuck=bt_stuck))
+                ui.set("bt-status", renderer.get_status_icon(cached_status, bt_stuck=bt_stuck, healing=healing, stalled=stalled))
 
             if self.show_detailed_status:
                 ui.set("bt-detail", detailed)


### PR DESCRIPTION
## Summary

Ports the reliability core of the bt-tether plugin (https://github.com/wsvdmeer/pwnagotchi-plugins/tree/main/bt-tether) into `pwnagotchi.bluetooth`, and adds recovery + diagnostics for the failure modes seen on shared WiFi+BT combo chips (brcmfmac), where the controller wedges or the PAN link goes "half-open" (connected but no traffic).

All changes are opt-in-safe: the watchdog defaults to dry-run (log only) and the reboot rung is off by default. Steady-state behaviour is unchanged.

## Recovery

**Half-open PAN watchdog** — on combo chips the link can report `connected` while no traffic passes (`bnep0` up, kernel logs `NETDEV WATCHDOG: transmit queue timed out`). Nothing detected this before, because the controller stays responsive and BlueZ still reports the device connected. The monitor now probes whether the phone is actually reachable over the PAN (ping, falling back to the ARP neighbour state), and also treats a PAN that stays **addressless** (DHCP starving — the request itself gets no reply on a dead link) as half-open. Dry-run by default. To avoid a flapping link never reaching the threshold, the fail counter **decays** on a good probe instead of hard-resetting.

**Layered controller recovery** — a wedged controller (`br-connection-busy`, `hci0: command tx timeout`, `-110`) is recovered through a ladder instead of a single restart:
1. `systemctl restart bluetooth` (daemon only)
2. reload the `hci_uart` kernel module (re-downloads the BT firmware) — clears wedges that survive both a daemon restart *and* a full reboot
3. reboot (opt-in via `reboot_on_stuck_bluetooth`, off by default, guarded against loops, true last resort)

The module-reload rung is the key finding: on the affected hardware a reboot often does **not** clear the wedge, while a module reload does (recovered in ~7s in testing). Watchdog heals route through this same ladder (shared rate limit + pairing-agent handling).

## Display + Web UI

- **On-screen states**: `BT:Recovering...` (recovery ladder running), `BT:Stalled?` (watchdog probing a suspect link), `BT:No IP` (PAN up but DHCP starving), alongside the existing stuck/connected/paired states. Naming matches the code/logs (`_recover_bluetooth`, "Recovering the Bluetooth stack").
- **Web UI pairing fixes**: scan spinner now clears reliably (poll budget exceeds scan duration; status always finalized); the status panel updates during a pair/connect (the endpoint now reports the core `CONNECTING`/`PAIRING` state instead of a stale IDLE/CONNECTED shadow); the scan list refreshes after pairing.
- **Web UI diagnostics**: a trouble banner surfaces stuck / recovering / no-IP / stalled states, and "Internet: Active" is gated on actually having an IP.
- **Security**: Bluetooth device names (attacker-controllable) are HTML-escaped before rendering, closing an XSS vector in the scan list and device summary.

## New config keys (`[main.plugins.bt-tether]`)

```toml
reconnect_fast_interval = 15       # faster retry right after a drop
nap_connect_timeout = 20           # cap on a single NAP connect attempt
fast_dhcp = true                   # skip the pointless ARP probe on the PAN link
watchdog_enabled = true            # detect a half-open PAN link
watchdog_dry_run = true            # log only; set false to auto-recover
watchdog_fail_threshold = 3        # consecutive unreachable probes before acting
reboot_on_stuck_bluetooth = false  # opt-in reboot when a restart+reload can't clear a wedge
```

## Testing

Validated live on two Pis (brcmfmac combo chip) over several hours:
- Watchdog caught genuine half-open links (confirmed independently: ARP `INCOMPLETE`, ping fail, TCP fail while BlueZ reported connected) with no false positives.
- The full ladder recovered wedged controllers autonomously and repeatedly — module reload succeeding where a daemon restart couldn't, **zero reboots needed**.
- Web UI driven in a real browser (Playwright): device-name escaping neutralizes an injection payload; the trouble banner and "No IP" gating render correctly across healthy / half-open / stuck / recovering states; zero console errors.
- Unit tests for the watchdog policy (including decay and addressless detection) and the UI renderer. Layer responsibilities audited (subprocess/dbus confined to `connection`/`network`).

## Notes

The underlying instability is a hardware/firmware limitation of the shared combo chip; this change makes the software ride it out and self-heal rather than requiring manual intervention. A dedicated USB BT adapter remains the durable cure.
