### PR TITLE
ui: guard LabeledValue.draw against None value

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -201,7 +201,10 @@ class Agent(Client, Automata, AsyncAdvertiser):
         return self._access_points
 
     def get_access_points(self):
-        whitelist = self._config['main']['whitelist']
+        # normalize the whitelist to lowercase so matching is case-insensitive
+        # regardless of how the user wrote MACs/hostnames in config.toml
+        # (MACs are conventionally displayed uppercase by routers/macOS/docs)
+        whitelist = [entry.lower() for entry in self._config['main']['whitelist']]
         aps = []
         try:
             s = self.session()
@@ -211,7 +214,7 @@ class Agent(Client, Automata, AsyncAdvertiser):
             for ap in s['wifi']['aps']:
                 if ap['encryption'] == '' or ap['encryption'] == 'OPEN':
                     continue
-                elif ap['hostname'] in whitelist or ap['mac'][:13].lower() in whitelist or ap['mac'].lower() in whitelist:
+                elif (ap['hostname'] or '').lower() in whitelist or ap['mac'][:13].lower() in whitelist or ap['mac'].lower() in whitelist:
                     continue
                 elif ap['channel'] not in self._supported_channels:
                     # a beacon can report any channel number it wants (seen

--- a/pwnagotchi/ui/components.py
+++ b/pwnagotchi/ui/components.py
@@ -87,9 +87,13 @@ class LabeledValue(Widget):
         self.label_spacing = label_spacing
 
     def draw(self, canvas, drawer):
+        # guard against a None value reaching PIL's drawer.text (raises
+        # "expected string or bytes"), mirroring the Text widget above.
+        # A peer advertising with a missing field can propagate None here.
+        value = self.value if self.value is not None else ''
         if self.label is None:
-            drawer.text(self.xy, self.value, font=self.label_font, fill=self.color)
+            drawer.text(self.xy, value, font=self.label_font, fill=self.color)
         else:
             pos = self.xy
             drawer.text(pos, self.label, font=self.label_font, fill=self.color)
-            drawer.text((pos[0] + self.label_spacing + 5 * len(self.label), pos[1]), self.value, font=self.text_font, fill=self.color)
+            drawer.text((pos[0] + self.label_spacing + 5 * len(self.label), pos[1]), value, font=self.text_font, fill=self.color)


### PR DESCRIPTION
LabeledValue.draw passed self.value straight to PIL's drawer.text with no None check, unlike the Text widget which already guards it. When a peer advertises with a missing field, the None reaches a LabeledValue (CH/APS/UP/PWND) and PIL raises 'expected string or bytes', crashing the render loop repeatedly. Coerce None to '' before drawing, matching the existing Text behaviour. Defensive fix at the render layer; the None origin in the peer/update_peers path may warrant a separate fix.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
