### PR TITLE
bt-tether: stop on_ui_update from blocking the display on bluetoothctl

### DIFF
--- a/pwnagotchi/bluetooth/monitor.py
+++ b/pwnagotchi/bluetooth/monitor.py
@@ -64,6 +64,15 @@ class ConnectionMonitor:
         # it. Beats a running counter, which a flapping link dilutes indefinitely.
         self._probe_history = deque(maxlen=self.watchdog_fail_threshold + 1)
 
+        # Latest poll snapshot for the UI thread (see get_ui_status). Written by
+        # the monitor thread every cycle and read by the plugin's on_ui_update so
+        # the display never makes its own blocking bluetoothctl/ip calls on the
+        # main loop. _picked_device caches the device chosen by _pick_device so
+        # the UI can show its name without a second trusted-devices lookup.
+        self._status_cache_lock = threading.Lock()
+        self._status_cache = None
+        self._picked_device = None
+
     def start(self):
         """Start the monitoring thread."""
         try:
@@ -85,7 +94,31 @@ class ConnectionMonitor:
         """True when the most recent peer probe failed on a live link - the
         connection LOOKS up but may be half-open. Reflects the latest probe so it
         clears as soon as one succeeds, rather than lingering for the whole window."""
-        return bool(self._probe_history) and self._probe_history[-1] is False
+        # Single indexing op so a concurrent clear() on the monitor thread can't
+        # wedge between a truthiness check and the [-1] read (would IndexError).
+        try:
+            return self._probe_history[-1] is False
+        except IndexError:
+            return False
+
+    def _cache_ui_status(self, mac, status):
+        """Store the latest poll so the UI thread can render it without blocking.
+        Called from the monitor thread each cycle."""
+        dev = self._picked_device
+        name = dev.name if (dev is not None and dev.mac == mac) else None
+        with self._status_cache_lock:
+            self._status_cache = {
+                "mac": mac,
+                "name": name,
+                "status": dict(status) if status else {},
+            }
+
+    def get_ui_status(self):
+        """Latest connection snapshot for the display, or None before the first
+        poll. Cheap and non-blocking - never triggers bluetoothctl/ip, so it is
+        safe to call from on_ui_update on the main loop (under the view lock)."""
+        with self._status_cache_lock:
+            return dict(self._status_cache) if self._status_cache else None
 
     def set_device(self, mac):
         """Tell the monitor which device to watch for drops (called after a successful connect)."""
@@ -152,14 +185,21 @@ class ConnectionMonitor:
             devices = self.connection.get_trusted_devices()
         except Exception as e:
             self.logger.debug(f"Could not list trusted devices: {e}")
+            self._picked_device = None
             return preferred
 
         if preferred and any(d.mac == preferred for d in devices):
+            self._picked_device = next((d for d in devices if d.mac == preferred), None)
             return preferred
         for d in devices:
             if getattr(d, "has_nap", False):
+                self._picked_device = d
                 return d.mac
-        return devices[0].mac if devices else None
+        if devices:
+            self._picked_device = devices[0]
+            return devices[0].mac
+        self._picked_device = None
+        return None
 
     def _loop(self):
         """Background monitoring loop."""
@@ -177,6 +217,10 @@ class ConnectionMonitor:
 
                 mac = self._pick_device()
                 if not mac:
+                    # No trusted device to watch (e.g. the last one was unpaired) -
+                    # clear the UI snapshot so the display drops to "no device"
+                    # instead of lingering on a stale connected/paired state.
+                    self._cache_ui_status(None, {})
                     self._adaptive_wait()
                     continue
 
@@ -184,6 +228,7 @@ class ConnectionMonitor:
                     self._current_mac = mac
 
                 status = self.connection.get_full_status(mac)
+                self._cache_ui_status(mac, status)
                 if not status:
                     self._adaptive_wait()
                     continue

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -158,50 +158,29 @@ class BtTether(Plugin):
             return
 
         try:
-            # Try to get status for stored phone_mac first, then check for any connected tethering device
-            cached_status = None
-            connected_device = None
+            # Render the monitor thread's latest snapshot instead of making our
+            # own bluetoothctl/ip calls here. on_ui_update runs on the main loop
+            # under the view lock, and get_full_status/get_trusted_devices block
+            # for several seconds when the phone is out of range - long enough to
+            # freeze the whole display (face, status, web frame). The monitor
+            # already polls the link on its own thread; we just show what it saw.
+            snapshot = self.bt.monitor.get_ui_status()
+            cached_status = (snapshot or {}).get("status") or {}
 
-            if self.phone_mac:
-                cached_status = self.bt.connection.get_full_status(self.phone_mac)
-                # Try to get the device name if we have a MAC
-                if cached_status and not self._phone_name:
-                    trusted_devices = self.bt.connection.get_trusted_devices()
-                    for device in trusted_devices:
-                        if device.mac == self.phone_mac:
-                            self._phone_name = device.name
-                            connected_device = device
-                            break
-
-            # Look for a connected device with NAP when the stored MAC has none.
-            # A paired but absent device still answers with a status dict, so
-            # testing the dict alone latches onto the first device ever seen and
-            # keeps reporting it after tethering moved to another one.
-            # The rescan result is copied over only when it is actually connected,
-            # so a scan that finds nothing leaves the previous status in place and
-            # the display keeps the P (paired) vs X (no device) distinction.
-            if not cached_status or not cached_status.get("connected", False):
-                trusted_devices = self.bt.connection.get_trusted_devices()
-                for device in trusted_devices:
-                    if device.connected and device.has_nap:
-                        new_status = self.bt.connection.get_full_status(device.mac)
-                        if new_status and new_status.get("connected"):
-                            cached_status = new_status
-                            self.phone_mac = device.mac
-                            self._phone_name = device.name
-                            connected_device = device
-                            break
-
-            cached_status = cached_status or {}
+            snap_name = (snapshot or {}).get("name")
+            if snap_name:
+                self._phone_name = snap_name
+            # Adopt a freshly-connected device's MAC when we don't have one yet,
+            # but never clobber a user-/config-chosen MAC from the display path.
+            snap_mac = (snapshot or {}).get("mac")
+            if snap_mac and cached_status.get("connected") and not self.phone_mac:
+                self.phone_mac = snap_mac
 
             # Track connection state for status reporting
             if cached_status.get("connected", False):
                 self._status = "CONNECTED"
             elif self._status == "CONNECTED":
                 self._status = "IDLE"
-
-            if connected_device and connected_device.name:
-                self._phone_name = connected_device.name
 
             # Rendering (glyph + detailed line) lives in the core UIRenderer so the
             # logic is shared and testable. Transient flags: bt_stuck is a wedged


### PR DESCRIPTION
## Problem

`on_ui_update` runs on the main loop while `View._lock` is held, but it called `get_full_status()` and `get_trusted_devices()` inline on every refresh. Those shell out to `bluetoothctl`/`ip` with multi-second timeouts, so when the phone is out of range a single refresh could block for ~10s — freezing the face, status line, every other UI element and the web frame push. The calls also contended with the monitor thread's own `bluetoothctl` usage.

## Fix

The connection monitor thread already polls the exact same status once per cycle. Cache that result (plus the picked device's name) and have `on_ui_update` render the snapshot instead, so the display path makes **no subprocess calls at all**.

- Connect/disconnect transitions still reflect immediately via the core service events; only the full IP/PAN detail lags by at most one poll interval.
- `link_stalled` is hardened against an `IndexError` when the monitor thread clears the probe history concurrently.
- The UI snapshot is cleared when the last trusted device goes away, so the display drops to "no device" instead of lingering on a stale connected/paired state.

## Testing

Deployed to a Pi Zero 2 W (BCM43430) running the bt-tether NAP tether:
- Plugin loads, monitor thread starts, status webhook reports `CONNECTED` with the correct IP, and the e-ink display shows `BT:<ip>` — all sourced from the cache with no `UI update error`/`BT:Error`.
- Service stable, 0 restarts.
- `py_compile` clean; the caching logic (device caching, snapshot copy, `link_stalled` on empty/after-clear, no-device clear) verified with a standalone stub test.