### PR TITLE
build: constrain Go build under QEMU emulation to avoid hang

### DIFF
--- a/stage3/02-bettercap-pwngrid/02-run-chroot.sh
+++ b/stage3/02-bettercap-pwngrid/02-run-chroot.sh
@@ -1,6 +1,16 @@
 #!/bin/bash -e
-
 export PATH=$PATH:/usr/local/go/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin
+
+
+# Under QEMU emulation (cross-building arm64 on x86), Go's signal-based async
+# preemption deadlocks and the multi-threaded compiler hangs. Constrain Go only
+# when emulated so native arm64 builders keep full parallelism.
+if [ -e /usr/bin/qemu-aarch64-static ] || [ -e /usr/bin/qemu-aarch64 ] || \
+   [ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ]; then
+    echo "[build] QEMU emulation detected - constraining Go build (asyncpreempt off, single-thread)"
+    export GODEBUG=asyncpreemptoff=1
+    export GOMAXPROCS=1
+fi
 
 # install go packages
 for pkg in bettercap pwngrid; do


### PR DESCRIPTION
Go's signal-based async preemption deadlocks and the multi-threaded compiler hangs when cross-building arm64 under user-mode QEMU. Detect emulation and set GODEBUG=asyncpreemptoff=1 + GOMAXPROCS=1 only then, so native arm64 builders keep full parallelism.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
