### PR TITLE
Add configurable USB gadget networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ Multiple units within close physical proximity can "talk" to each other, adverti
 https://github.com/jayofelony/pwnagotchi/wiki 
 https://pwnagotchi.org
 
+### USB gadget network configuration
+
+Recent images use `rpi-usb-gadget` to switch the `usb0` link automatically
+between a host DHCP client and a Pi-hosted shared network. Management from
+Pwnagotchi is opt-in. To select a predictable, non-conflicting shared subnet,
+add the following to `/etc/pwnagotchi/config.toml`:
+
+```toml
+[usb_gadget]
+manage = true
+mode = "shared"
+interface = "usb0"
+shared_address = "10.12.195.1/28"
+check_conflicts = true
+```
+
+Valid modes are `auto`, `client`, and `shared`. `auto` preserves the upstream
+ICS watcher behavior. Settings are applied on boot; they can also be applied
+with `sudo systemctl restart pwnagotchi-usb-gadget.service`. Switching the
+active mode or shared address can disconnect the current USB/SSH session.
+
 ## Links
 
 | &nbsp;    | Official Links                                           |

--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -236,6 +236,15 @@ enabled = false
 rotation = 180
 type = "waveshare_4"
 
+[usb_gadget]
+# Opt in to managing rpi-usb-gadget's NetworkManager profiles from config.toml.
+# Changing the active mode can disconnect the current USB/SSH session.
+manage = false
+mode = "auto" # auto, client, or shared
+interface = "usb0"
+shared_address = "10.12.194.1/28"
+check_conflicts = true
+
 [bettercap]
 handshakes = "/etc/pwnagotchi/handshakes"
 silence = [

--- a/pwnagotchi/usb_gadget.py
+++ b/pwnagotchi/usb_gadget.py
@@ -1,0 +1,282 @@
+import argparse
+import ipaddress
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+
+import tomlkit
+
+
+CLIENT_PROFILE = "USB Gadget (client)"
+SHARED_PROFILE = "USB Gadget (shared)"
+WATCHER_SERVICE = "rpi-usb-gadget-ics.service"
+
+DEFAULT_OPTIONS = {
+    "manage": False,
+    "mode": "auto",
+    "interface": "usb0",
+    "shared_address": "10.12.194.1/28",
+    "check_conflicts": True,
+}
+
+
+class UsbGadgetConfigError(ValueError):
+    pass
+
+
+def load_options(config_path):
+    options = dict(DEFAULT_OPTIONS)
+    if not os.path.exists(config_path):
+        return options
+
+    with open(config_path, encoding="utf-8") as config_file:
+        config = tomlkit.load(config_file)
+
+    configured = config.get("usb_gadget", {})
+    if not isinstance(configured, dict):
+        raise UsbGadgetConfigError("[usb_gadget] must be a TOML table")
+
+    for key in DEFAULT_OPTIONS:
+        if key in configured:
+            options[key] = configured[key]
+    return options
+
+
+def validate_options(options):
+    mode = str(options["mode"]).lower()
+    if mode not in ("auto", "client", "shared"):
+        raise UsbGadgetConfigError(
+            "usb_gadget.mode must be one of: auto, client, shared"
+        )
+
+    interface = str(options["interface"]).strip()
+    if not interface:
+        raise UsbGadgetConfigError("usb_gadget.interface cannot be empty")
+
+    try:
+        shared_address = ipaddress.ip_interface(str(options["shared_address"]))
+    except ValueError as error:
+        raise UsbGadgetConfigError(
+            "usb_gadget.shared_address must be a valid IPv4 CIDR"
+        ) from error
+
+    if shared_address.version != 4:
+        raise UsbGadgetConfigError(
+            "usb_gadget.shared_address must be an IPv4 CIDR"
+        )
+    if shared_address.network.prefixlen > 30:
+        raise UsbGadgetConfigError(
+            "usb_gadget.shared_address must leave room for a DHCP client"
+        )
+    if shared_address.ip in (
+        shared_address.network.network_address,
+        shared_address.network.broadcast_address,
+    ):
+        raise UsbGadgetConfigError(
+            "usb_gadget.shared_address must be a usable host address"
+        )
+
+    validated = dict(options)
+    validated["mode"] = mode
+    validated["interface"] = interface
+    validated["shared_address"] = str(shared_address)
+    validated["manage"] = bool(options["manage"])
+    validated["check_conflicts"] = bool(options["check_conflicts"])
+    return validated
+
+
+def run_command(command):
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        message = "%s failed" % command[0]
+        if detail:
+            message += ": %s" % detail
+        raise UsbGadgetConfigError(message) from error
+    return result.stdout.strip()
+
+
+def find_local_conflicts(network, interface, run=run_command):
+    conflicts = set()
+
+    addresses = json.loads(run(["ip", "-j", "-4", "address", "show"]))
+    for device in addresses:
+        if device.get("ifname") == interface:
+            continue
+        for address in device.get("addr_info", []):
+            if address.get("family") != "inet" or "local" not in address:
+                continue
+            local_network = ipaddress.ip_network(
+                "%s/%s" % (address["local"], address["prefixlen"]),
+                strict=False,
+            )
+            if network.overlaps(local_network):
+                conflicts.add(
+                    "%s on %s" % (local_network, device.get("ifname", "?"))
+                )
+
+    routes = json.loads(run(["ip", "-j", "-4", "route", "show"]))
+    for route in routes:
+        destination = route.get("dst")
+        if route.get("dev") == interface or destination in (None, "default"):
+            continue
+        try:
+            route_network = ipaddress.ip_network(destination, strict=False)
+        except ValueError:
+            continue
+        if network.overlaps(route_network):
+            conflicts.add(
+                "route %s via %s" % (route_network, route.get("dev", "?"))
+            )
+
+    return sorted(conflicts)
+
+
+def apply_options(options, run=run_command):
+    options = validate_options(options)
+    if not options["manage"]:
+        logging.info("USB gadget configuration management is disabled")
+        return False
+
+    shared_address = ipaddress.ip_interface(options["shared_address"])
+    if options["check_conflicts"] and options["mode"] != "client":
+        conflicts = find_local_conflicts(
+            shared_address.network,
+            options["interface"],
+            run=run,
+        )
+        if conflicts:
+            raise UsbGadgetConfigError(
+                "USB gadget shared network %s overlaps with %s"
+                % (shared_address.network, ", ".join(conflicts))
+            )
+
+    if options["mode"] == "auto":
+        run(["systemctl", "enable", "--now", WATCHER_SERVICE])
+    else:
+        # Stop the watcher for this boot without disabling it persistently. If
+        # management is later turned off, auto mode returns on the next boot.
+        run(["systemctl", "stop", WATCHER_SERVICE])
+
+    current_address = run(
+        [
+            "nmcli",
+            "-g",
+            "ipv4.addresses",
+            "connection",
+            "show",
+            SHARED_PROFILE,
+        ]
+    )
+    address_changed = current_address != options["shared_address"]
+    if address_changed:
+        run(
+            [
+                "nmcli",
+                "connection",
+                "modify",
+                SHARED_PROFILE,
+                "ipv4.method",
+                "shared",
+                "ipv4.addresses",
+                options["shared_address"],
+            ]
+        )
+
+    active_profile = run(
+        [
+            "nmcli",
+            "-g",
+            "GENERAL.CONNECTION",
+            "device",
+            "show",
+            options["interface"],
+        ]
+    )
+    if options["mode"] == "auto":
+        desired_profile = active_profile
+        must_activate = address_changed and active_profile == SHARED_PROFILE
+    else:
+        desired_profile = (
+            CLIENT_PROFILE if options["mode"] == "client" else SHARED_PROFILE
+        )
+        must_activate = active_profile != desired_profile or (
+            address_changed and desired_profile == SHARED_PROFILE
+        )
+
+    if must_activate:
+        logging.warning(
+            "Switching %s to %s; the current USB connection may disconnect",
+            options["interface"],
+            desired_profile,
+        )
+        run(
+            [
+                "nmcli",
+                "connection",
+                "up",
+                desired_profile,
+                "ifname",
+                options["interface"],
+            ]
+        )
+        return True
+
+    return address_changed
+
+
+def check_commands():
+    missing = [
+        name for name in ("ip", "nmcli", "systemctl") if not shutil.which(name)
+    ]
+    if missing:
+        raise UsbGadgetConfigError(
+            "required command(s) not found: %s" % ", ".join(missing)
+        )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Apply Pwnagotchi USB gadget settings to NetworkManager"
+    )
+    parser.add_argument(
+        "--config",
+        default="/etc/pwnagotchi/config.toml",
+        help="Pwnagotchi user configuration file",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    try:
+        options = load_options(args.config)
+        if not options["manage"]:
+            logging.info("USB gadget configuration management is disabled")
+            return 0
+        check_commands()
+        changed = apply_options(options)
+        if changed:
+            logging.info("USB gadget configuration applied")
+        else:
+            logging.info("USB gadget configuration is already current")
+        return 0
+    except (
+        OSError,
+        subprocess.CalledProcessError,
+        tomlkit.exceptions.ParseError,
+        UsbGadgetConfigError,
+    ) as error:
+        logging.error("could not configure USB gadget: %s", error)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,4 @@ Download = "https://github.com/jayofelony/pwnagotchi/releases/latest"
 
 [project.scripts]
 pwnagotchi = "pwnagotchi.cli:pwnagotchi_cli"
+pwnagotchi-usb-gadget = "pwnagotchi.usb_gadget:main"

--- a/stage3/06-patches/00-run.sh
+++ b/stage3/06-patches/00-run.sh
@@ -28,6 +28,7 @@ install -v -m 644 files/pwnagotchi_completion.sh "${ROOTFS_DIR}/etc/bash_complet
 echo -e "\e[32m### Installing /etc/systemd/system/ files ###\e[0m"
 install -v -m 644 files/bettercap.service "${ROOTFS_DIR}/etc/systemd/system/bettercap.service"
 install -v -m 644 files/pwnagotchi.service "${ROOTFS_DIR}/etc/systemd/system/pwnagotchi.service"
+install -v -m 644 files/pwnagotchi-usb-gadget.service "${ROOTFS_DIR}/etc/systemd/system/pwnagotchi-usb-gadget.service"
 install -v -m 644 files/pwngrid-peer.service "${ROOTFS_DIR}/etc/systemd/system/pwngrid-peer.service"
 install -v -m 644 files/auto-update.service "${ROOTFS_DIR}/etc/systemd/system/auto-update.service"
 install -v -m 644 files/auto-update.timer "${ROOTFS_DIR}/etc/systemd/system/auto-update.timer"

--- a/stage3/06-patches/01-run-chroot.sh
+++ b/stage3/06-patches/01-run-chroot.sh
@@ -6,7 +6,7 @@ chmod +x /usr/local/bin/*
 chmod +x /etc/update-motd.d/*
 
 echo -e "\e[32m### Enabling services ###\e[0m"
-systemctl enable bettercap pwngrid-peer pwnagotchi bluetooth.service auto-update.timer brcmfmac-watchdog.service
+systemctl enable bettercap pwngrid-peer pwnagotchi pwnagotchi-usb-gadget.service bluetooth.service auto-update.timer brcmfmac-watchdog.service
 systemctl disable wpa_supplicant apt-daily-upgrade.service apt-daily-upgrade.timer apt-daily.service apt-daily.timer
 
 echo -e "\e[32m### Disable apt packages from upgrading ###\e[0m"

--- a/stage3/06-patches/files/auto-update.sh
+++ b/stage3/06-patches/files/auto-update.sh
@@ -101,6 +101,7 @@ sync_file "auto-update.sh" "/usr/bin/auto-update.sh" 755
 sync_file "brcmfmac-watchdog.sh" "/usr/bin/brcmfmac-watchdog.sh" 755
 sync_file "01-motd" "/etc/update-motd.d/01-motd" 755
 sync_file "pwnagotchi.service" "/etc/systemd/system/pwnagotchi.service" 644
+sync_file "pwnagotchi-usb-gadget.service" "/etc/systemd/system/pwnagotchi-usb-gadget.service" 644
 sync_file "bettercap.service" "/etc/systemd/system/bettercap.service" 644
 sync_file "pwngrid-peer.service" "/etc/systemd/system/pwngrid-peer.service" 644
 sync_file "auto-update.service" "/etc/systemd/system/auto-update.service" 644
@@ -119,7 +120,7 @@ fi
 # idempotent, so this is safe to run unconditionally on every update rather
 # than trying to detect "is this the first time" - it converges an
 # already-enabled or even a previously-half-applied device to the same state.
-systemctl enable brcmfmac-watchdog.service
+systemctl enable brcmfmac-watchdog.service pwnagotchi-usb-gadget.service
 
 # pip install already copied the package into the venv and sync_file copied
 # out the system files it needs, so the clone itself is just clutter now.

--- a/stage3/06-patches/files/pwnagotchi-usb-gadget.service
+++ b/stage3/06-patches/files/pwnagotchi-usb-gadget.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Apply Pwnagotchi USB gadget network configuration
+Documentation=https://github.com/jayofelony/pwnagotchi
+Wants=NetworkManager.service
+After=cloud-final.service NetworkManager.service rpi-usb-gadget-ics.service
+Before=pwnagotchi.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/.pwn/bin/pwnagotchi-usb-gadget
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/stage3/06-patches/files/pwnagotchi.service
+++ b/stage3/06-patches/files/pwnagotchi.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=pwnagotchi Deep Reinforcement Learning instrumenting bettercap for WiFI pwning.
 Documentation=https://pwnagotchi.org
-Wants=network.target
-After=pwngrid-peer.service
+Wants=network.target pwnagotchi-usb-gadget.service
+After=pwngrid-peer.service pwnagotchi-usb-gadget.service
 
 [Service]
 Type=simple

--- a/tests/test_usb_gadget.py
+++ b/tests/test_usb_gadget.py
@@ -1,0 +1,190 @@
+import ipaddress
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from pwnagotchi.usb_gadget import (
+    CLIENT_PROFILE,
+    SHARED_PROFILE,
+    WATCHER_SERVICE,
+    UsbGadgetConfigError,
+    apply_options,
+    find_local_conflicts,
+    load_options,
+    validate_options,
+)
+
+
+class FakeRunner:
+    def __init__(self, responses=None):
+        self.responses = responses or {}
+        self.commands = []
+
+    def __call__(self, command):
+        command = tuple(command)
+        self.commands.append(command)
+        return self.responses.get(command, "")
+
+
+class UsbGadgetTests(unittest.TestCase):
+    def test_missing_config_keeps_management_disabled(self):
+        options = load_options("/path/that/does/not/exist")
+        self.assertFalse(options["manage"])
+        self.assertEqual(options["mode"], "auto")
+
+    def test_loads_usb_gadget_table(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "config.toml"
+            config.write_text(
+                '[usb_gadget]\nmanage = true\nmode = "shared"\n'
+                'shared_address = "10.12.195.1/28"\n',
+                encoding="utf-8",
+            )
+            options = load_options(config)
+
+        self.assertTrue(options["manage"])
+        self.assertEqual(options["mode"], "shared")
+        self.assertEqual(options["shared_address"], "10.12.195.1/28")
+
+    def test_rejects_invalid_mode_and_address(self):
+        with self.assertRaises(UsbGadgetConfigError):
+            validate_options({
+                "manage": True,
+                "mode": "invalid",
+                "interface": "usb0",
+                "shared_address": "10.12.194.1/28",
+                "check_conflicts": True,
+            })
+        with self.assertRaises(UsbGadgetConfigError):
+            validate_options({
+                "manage": True,
+                "mode": "shared",
+                "interface": "usb0",
+                "shared_address": "not-an-address",
+                "check_conflicts": True,
+            })
+
+    def test_detects_non_usb_address_and_route_conflicts(self):
+        runner = FakeRunner({
+            ("ip", "-j", "-4", "address", "show"): json.dumps([
+                {
+                    "ifname": "wlan0",
+                    "addr_info": [{
+                        "family": "inet",
+                        "local": "10.12.195.20",
+                        "prefixlen": 24,
+                    }],
+                },
+                {
+                    "ifname": "usb0",
+                    "addr_info": [{
+                        "family": "inet",
+                        "local": "10.12.195.1",
+                        "prefixlen": 28,
+                    }],
+                },
+            ]),
+            ("ip", "-j", "-4", "route", "show"): json.dumps([
+                {"dst": "10.12.195.0/25", "dev": "eth0"},
+                {"dst": "default", "dev": "wlan0"},
+            ]),
+        })
+
+        conflicts = find_local_conflicts(
+            ipaddress.ip_network("10.12.195.0/28"),
+            "usb0",
+            runner,
+        )
+
+        self.assertEqual(len(conflicts), 2)
+
+    def test_auto_mode_updates_address_and_enables_watcher(self):
+        runner = FakeRunner({
+            ("ip", "-j", "-4", "address", "show"): "[]",
+            ("ip", "-j", "-4", "route", "show"): "[]",
+            (
+                "nmcli", "-g", "ipv4.addresses", "connection", "show", SHARED_PROFILE
+            ): "10.12.194.1/28",
+            (
+                "nmcli", "-g", "GENERAL.CONNECTION", "device", "show", "usb0"
+            ): CLIENT_PROFILE,
+        })
+        changed = apply_options({
+            "manage": True,
+            "mode": "auto",
+            "interface": "usb0",
+            "shared_address": "10.12.195.1/28",
+            "check_conflicts": True,
+        }, runner)
+
+        self.assertTrue(changed)
+        self.assertIn(
+            ("systemctl", "enable", "--now", WATCHER_SERVICE),
+            runner.commands,
+        )
+
+    def test_active_shared_profile_is_reapplied_after_address_change(self):
+        runner = FakeRunner({
+            ("ip", "-j", "-4", "address", "show"): "[]",
+            ("ip", "-j", "-4", "route", "show"): "[]",
+            (
+                "nmcli", "-g", "ipv4.addresses", "connection", "show", SHARED_PROFILE
+            ): "10.12.194.1/28",
+            (
+                "nmcli", "-g", "GENERAL.CONNECTION", "device", "show", "usb0"
+            ): SHARED_PROFILE,
+        })
+        changed = apply_options({
+            "manage": True,
+            "mode": "shared",
+            "interface": "usb0",
+            "shared_address": "10.12.195.1/28",
+            "check_conflicts": True,
+        }, runner)
+
+        self.assertTrue(changed)
+        self.assertIn(
+            ("nmcli", "connection", "up", SHARED_PROFILE, "ifname", "usb0"),
+            runner.commands,
+        )
+        self.assertIn(
+            (
+                "nmcli", "connection", "modify", SHARED_PROFILE,
+                "ipv4.method", "shared", "ipv4.addresses", "10.12.195.1/28",
+            ),
+            runner.commands,
+        )
+
+    def test_forced_client_stops_watcher_and_switches_profile(self):
+        runner = FakeRunner({
+            ("ip", "-j", "-4", "address", "show"): "[]",
+            ("ip", "-j", "-4", "route", "show"): "[]",
+            (
+                "nmcli", "-g", "ipv4.addresses", "connection", "show", SHARED_PROFILE
+            ): "10.12.194.1/28",
+            (
+                "nmcli", "-g", "GENERAL.CONNECTION", "device", "show", "usb0"
+            ): SHARED_PROFILE,
+        })
+        changed = apply_options({
+            "manage": True,
+            "mode": "client",
+            "interface": "usb0",
+            "shared_address": "10.12.194.1/28",
+            "check_conflicts": True,
+        }, runner)
+
+        self.assertTrue(changed)
+        self.assertIn(
+            ("systemctl", "stop", WATCHER_SERVICE),
+            runner.commands,
+        )
+        self.assertIn(
+            ("nmcli", "connection", "up", CLIENT_PROFILE, "ifname", "usb0"),
+            runner.commands,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds opt-in management of rpi-usb-gadget networking from /etc/pwnagotchi/config.toml.

The new usb_gadget table supports:

- auto, client, and shared operating modes
- a configurable shared IPv4 CIDR
- local interface and route conflict detection
- safe coordination with rpi-usb-gadget-ics.service
- idempotent NetworkManager profile updates

A dedicated oneshot service applies the settings after NetworkManager and cloud-init, before the main Pwnagotchi service. Management remains disabled by default, preserving current behavior.

Closes #638.

## Motivation and Context

Host Internet Connection Sharing can assign a subnet that overlaps the host LAN, particularly the macOS 192.168.2.0/24 default. Multiple Pwnagotchis using the standard shared profile can also expose overlapping 10.12.194.0/28 networks. Users currently need to discover and modify NetworkManager profiles manually.

Forced modes stop the ICS watcher only for the current boot. Turning management off therefore restores the package default auto behavior on the next boot.

## How Has This Been Tested?

- python3 -m unittest discover -s tests -v: 7 tests passed
- python3 -m compileall for the new module and tests
- bash -n for all modified image-build and update scripts
- git diff --check
- built the project wheel successfully with pip wheel

The NetworkManager and systemd calls are covered with a fake command runner. Hardware validation on a Pwnagotchi remains to be completed before marking this PR ready for review.

## Type of change

- [x] New feature (non-breaking)
- [ ] Bug fix
- [ ] Breaking change

## Checklist

- [x] Raised issue #638 before submitting the change
- [x] Code follows the existing project structure
- [x] Updated README and defaults.toml documentation
- [x] Commit includes the required DCO Signed-off-by line
- [x] PR is a draft pending maintainer feedback and hardware validation